### PR TITLE
Fix reading of "MAX", "MIN" attributes

### DIFF
--- a/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
@@ -62,6 +62,27 @@ namespace ReqIFSharp
         public int Max { get; set; }
 
         /// <summary>
+        /// Generates a <see cref="AttributeDefinition"/> object from its XML representation.
+        /// </summary>
+        /// <param name="reader">
+        /// an instance of <see cref="XmlReader"/>
+        /// </param>
+        public override void ReadXml(XmlReader reader)
+        {
+            base.ReadXml(reader);
+
+            if (int.TryParse(reader.GetAttribute("MAX"), out int max))
+            {
+                this.Max = max;
+            }
+
+            if (int.TryParse(reader.GetAttribute("MIN"), out int min))
+            {
+                this.Min = min;
+            }
+        }
+
+        /// <summary>
         /// Converts a <see cref="AttributeDefinition"/> object into its XML representation.
         /// </summary>
         /// <param name="writer">

--- a/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
@@ -62,6 +62,27 @@ namespace ReqIFSharp
         public double Max { get; set; }
 
         /// <summary>
+        /// Generates a <see cref="AttributeDefinition"/> object from its XML representation.
+        /// </summary>
+        /// <param name="reader">
+        /// an instance of <see cref="XmlReader"/>
+        /// </param>
+        public override void ReadXml(XmlReader reader)
+        {
+            base.ReadXml(reader);
+
+            if (double.TryParse(reader.GetAttribute("MAX"), out double max))
+            {
+                this.Max = max;
+            }
+
+            if (double.TryParse(reader.GetAttribute("MIN"), out double min))
+            {
+                this.Min = min;
+            }
+        }
+
+        /// <summary>
         /// Converts a <see cref="DatatypeDefinitionReal"/> object into its XML representation.
         /// </summary>
         /// <param name="writer">


### PR DESCRIPTION
Fix reading of "MAX", "MIN" attributes for "DATATYPE-DEFINITION-INTEGER" and "DATATYPE-DEFINITION-REAL"

I plan to add tests later in another PR. Sorry, but I do not have any free time at this moment. 