### PR TITLE
Fixed wrong serialization/deserialization in datatype definition classes by using XmlConvert instead of int/double Parse.

### DIFF
--- a/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
@@ -20,80 +20,81 @@
 
 namespace ReqIFSharp
 {
-    using System.Globalization;
-    using System.Xml;
+	using System.Xml;
 
-    /// <summary>
-    /// The purpose of the <see cref="DatatypeDefinitionBoolean"/> class is to define the primitive <see cref="int"/> data type
-    /// </summary>
-    /// <remarks>
-    /// This element defines a data type for the representation of Integer data values in the Exchange Document.
-    /// The representation of data values shall comply with the definitions in http://www.w3.org/TR/xmlschema-2/#integer
-    /// </remarks>
-    public class DatatypeDefinitionInteger : DatatypeDefinitionSimple
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DatatypeDefinitionInteger"/> class.
-        /// </summary>
-        public DatatypeDefinitionInteger()
-        {
-        }
+	/// <summary>
+	/// The purpose of the <see cref="DatatypeDefinitionBoolean"/> class is to define the primitive <see cref="int"/> data type
+	/// </summary>
+	/// <remarks>
+	/// This element defines a data type for the representation of Integer data values in the Exchange Document.
+	/// The representation of data values shall comply with the definitions in http://www.w3.org/TR/xmlschema-2/#integer
+	/// </remarks>
+	public class DatatypeDefinitionInteger : DatatypeDefinitionSimple
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DatatypeDefinitionInteger"/> class.
+		/// </summary>
+		public DatatypeDefinitionInteger()
+		{
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DatatypeDefinitionInteger"/> class.
-        /// </summary>
-        /// <param name="reqIfContent">
-        /// The owning <see cref="reqIfContent"/>
-        /// </param>
-        internal DatatypeDefinitionInteger(ReqIFContent reqIfContent) 
-            : base(reqIfContent)            
-        {
-            this.ReqIFContent = reqIfContent;
-        }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DatatypeDefinitionInteger"/> class.
+		/// </summary>
+		/// <param name="reqIfContent">
+		/// The owning <see cref="reqIfContent"/>
+		/// </param>
+		internal DatatypeDefinitionInteger( ReqIFContent reqIfContent )
+			: base( reqIfContent )
+		{
+			this.ReqIFContent = reqIfContent;
+		}
 
-        /// <summary>
-        /// Gets or sets a value that denotes the largest negative data value representable by this data type.
-        /// </summary>
-        public int Min { get; set; }
+		/// <summary>
+		/// Gets or sets a value that denotes the largest negative data value representable by this data type.
+		/// </summary>
+		public int Min { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value that denotes the largest positive data value representable by this data type.
-        /// </summary>
-        public int Max { get; set; }
+		/// <summary>
+		/// Gets or sets a value that denotes the largest positive data value representable by this data type.
+		/// </summary>
+		public int Max { get; set; }
 
-        /// <summary>
-        /// Generates a <see cref="AttributeDefinition"/> object from its XML representation.
-        /// </summary>
-        /// <param name="reader">
-        /// an instance of <see cref="XmlReader"/>
-        /// </param>
-        public override void ReadXml(XmlReader reader)
-        {
-            base.ReadXml(reader);
+		/// <summary>
+		/// Generates a <see cref="AttributeDefinition"/> object from its XML representation.
+		/// </summary>
+		/// <param name="reader">
+		/// an instance of <see cref="XmlReader"/>
+		/// </param>
+		public override void ReadXml( XmlReader reader )
+		{
+			base.ReadXml( reader );
 
-            if (int.TryParse(reader.GetAttribute("MAX"), out int max))
-            {
-                this.Max = max;
-            }
+			var value = reader.GetAttribute( "MAX" );
+			if ( !string.IsNullOrEmpty( value ) )
+			{
+				this.Max = XmlConvert.ToInt32( value );
+			}
 
-            if (int.TryParse(reader.GetAttribute("MIN"), out int min))
-            {
-                this.Min = min;
-            }
-        }
+			value = reader.GetAttribute( "MIN" );
+			if ( !string.IsNullOrEmpty( value ) )
+			{
+				this.Min = XmlConvert.ToInt32( value );
+			}
+		}
 
-        /// <summary>
-        /// Converts a <see cref="AttributeDefinition"/> object into its XML representation.
-        /// </summary>
-        /// <param name="writer">
-        /// an instance of <see cref="XmlWriter"/>
-        /// </param>
-        public override void WriteXml(XmlWriter writer)
-        {
-            base.WriteXml(writer);
+		/// <summary>
+		/// Converts a <see cref="AttributeDefinition"/> object into its XML representation.
+		/// </summary>
+		/// <param name="writer">
+		/// an instance of <see cref="XmlWriter"/>
+		/// </param>
+		public override void WriteXml( XmlWriter writer )
+		{
+			base.WriteXml( writer );
 
-            writer.WriteAttributeString("MIN", this.Min.ToString(NumberFormatInfo.InvariantInfo));
-            writer.WriteAttributeString("MAX", this.Max.ToString(NumberFormatInfo.InvariantInfo));
-        }
-    }
+			writer.WriteAttributeString( "MIN", XmlConvert.ToString( this.Min ) );
+			writer.WriteAttributeString( "MAX", XmlConvert.ToString( this.Max ) );
+		}
+	}
 }

--- a/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
@@ -20,81 +20,89 @@
 
 namespace ReqIFSharp
 {
-    using System.Xml;
-    
-    /// <summary>
-    /// This element defines a data type for the representation of Real data values in the Exchange Document.
-    /// </summary>
-    public class DatatypeDefinitionReal : DatatypeDefinitionSimple
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DatatypeDefinitionReal"/> class.
-        /// </summary>
-        public DatatypeDefinitionReal()
-        {
-        }
+	using System.Xml;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DatatypeDefinitionReal"/> class.
-        /// </summary>
-        /// <param name="reqIfContent">
-        /// The owning <see cref="reqIfContent"/>
-        /// </param>
-        internal DatatypeDefinitionReal(ReqIFContent reqIfContent) 
-            : base(reqIfContent)            
-        {
-            this.ReqIFContent = reqIfContent;
-        }
+	/// <summary>
+	/// This element defines a data type for the representation of Real data values in the Exchange Document.
+	/// </summary>
+	public class DatatypeDefinitionReal : DatatypeDefinitionSimple
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DatatypeDefinitionReal"/> class.
+		/// </summary>
+		public DatatypeDefinitionReal()
+		{
+		}
 
-        /// <summary>
-        /// Gets or sets a value that Denotes the supported maximum precision of real numbers represented by this data type.
-        /// </summary>
-        public int Accuracy { get; set; }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DatatypeDefinitionReal"/> class.
+		/// </summary>
+		/// <param name="reqIfContent">
+		/// The owning <see cref="reqIfContent"/>
+		/// </param>
+		internal DatatypeDefinitionReal( ReqIFContent reqIfContent )
+			: base( reqIfContent )
+		{
+			this.ReqIFContent = reqIfContent;
+		}
 
-        /// <summary>
-        /// Gets or sets a value that denotes the largest negative data value representable by this data type.
-        /// </summary>
-        public double Min { get; set; }
+		/// <summary>
+		/// Gets or sets a value that Denotes the supported maximum precision of real numbers represented by this data type.
+		/// </summary>
+		public int Accuracy { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value that denotes the largest positive data value representable by this data type.
-        /// </summary>
-        public double Max { get; set; }
+		/// <summary>
+		/// Gets or sets a value that denotes the largest negative data value representable by this data type.
+		/// </summary>
+		public double Min { get; set; }
 
-        /// <summary>
-        /// Generates a <see cref="AttributeDefinition"/> object from its XML representation.
-        /// </summary>
-        /// <param name="reader">
-        /// an instance of <see cref="XmlReader"/>
-        /// </param>
-        public override void ReadXml(XmlReader reader)
-        {
-            base.ReadXml(reader);
+		/// <summary>
+		/// Gets or sets a value that denotes the largest positive data value representable by this data type.
+		/// </summary>
+		public double Max { get; set; }
 
-            if (double.TryParse(reader.GetAttribute("MAX"), out double max))
-            {
-                this.Max = max;
-            }
+		/// <summary>
+		/// Generates a <see cref="AttributeDefinition"/> object from its XML representation.
+		/// </summary>
+		/// <param name="reader">
+		/// an instance of <see cref="XmlReader"/>
+		/// </param>
+		public override void ReadXml( XmlReader reader )
+		{
+			base.ReadXml( reader );
 
-            if (double.TryParse(reader.GetAttribute("MIN"), out double min))
-            {
-                this.Min = min;
-            }
-        }
+			var value = reader.GetAttribute( "ACCURACY" );
+			if ( !string.IsNullOrEmpty( value ) )
+			{
+				this.Accuracy = XmlConvert.ToInt32( value );
+			}
 
-        /// <summary>
-        /// Converts a <see cref="DatatypeDefinitionReal"/> object into its XML representation.
-        /// </summary>
-        /// <param name="writer">
-        /// an instance of <see cref="XmlWriter"/>
-        /// </param>
-        public override void WriteXml(XmlWriter writer)
-        {
-            base.WriteXml(writer);
+			value = reader.GetAttribute( "MAX" );
+			if ( !string.IsNullOrEmpty( value ) )
+			{
+				this.Max = XmlConvert.ToDouble( value );
+			}
 
-            writer.WriteAttributeString("ACCURACY", this.Accuracy.ToString());
-            writer.WriteAttributeString("MIN", this.Min.ToString());
-            writer.WriteAttributeString("MAX", this.Max.ToString());
-        }
-    }
+			value = reader.GetAttribute( "MIN" );
+			if ( !string.IsNullOrEmpty( value ) )
+			{
+				this.Min = XmlConvert.ToDouble( value );
+			}
+		}
+
+		/// <summary>
+		/// Converts a <see cref="DatatypeDefinitionReal"/> object into its XML representation.
+		/// </summary>
+		/// <param name="writer">
+		/// an instance of <see cref="XmlWriter"/>
+		/// </param>
+		public override void WriteXml( XmlWriter writer )
+		{
+			base.WriteXml( writer );
+
+			writer.WriteAttributeString( "ACCURACY", XmlConvert.ToString( this.Accuracy ) );
+			writer.WriteAttributeString( "MIN", XmlConvert.ToString( this.Min ) );
+			writer.WriteAttributeString( "MAX", XmlConvert.ToString( this.Max ) );
+		}
+	}
 }

--- a/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
@@ -20,52 +20,69 @@
 
 namespace ReqIFSharp
 {
-    using System.Globalization;
-    using System.Xml;
-    
-    /// <summary>
-    /// The purpose of the <see cref="DatatypeDefinitionBoolean"/> class is to define the primitive <see cref="string"/> data type    
-    /// </summary>
-    /// <remarks>
-    /// This element defines a data type for the representation of String data values in the Exchange Document.
-    /// </remarks>    
-    public class DatatypeDefinitionString : DatatypeDefinitionSimple
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DatatypeDefinitionString"/> class.
-        /// </summary>
-        public DatatypeDefinitionString()
-        {
-        }
+	using System.Globalization;
+	using System.Xml;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DatatypeDefinitionString"/> class.
-        /// </summary>
-        /// <param name="reqIfContent">
-        /// The owning <see cref="reqIfContent"/>
-        /// </param>
-        internal DatatypeDefinitionString(ReqIFContent reqIfContent) 
-            : base(reqIfContent)            
-        {
-            this.ReqIFContent = reqIfContent;
-        }
+	/// <summary>
+	/// The purpose of the <see cref="DatatypeDefinitionBoolean"/> class is to define the primitive <see cref="string"/> data type    
+	/// </summary>
+	/// <remarks>
+	/// This element defines a data type for the representation of String data values in the Exchange Document.
+	/// </remarks>    
+	public class DatatypeDefinitionString : DatatypeDefinitionSimple
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DatatypeDefinitionString"/> class.
+		/// </summary>
+		public DatatypeDefinitionString()
+		{
+		}
 
-        /// <summary>
-        /// Gets or sets the maximum permissible string length
-        /// </summary>        
-        public int MaxLength { get; set; }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DatatypeDefinitionString"/> class.
+		/// </summary>
+		/// <param name="reqIfContent">
+		/// The owning <see cref="reqIfContent"/>
+		/// </param>
+		internal DatatypeDefinitionString( ReqIFContent reqIfContent )
+			: base( reqIfContent )
+		{
+			this.ReqIFContent = reqIfContent;
+		}
 
-        /// <summary>
-        /// Converts a <see cref="DatatypeDefinitionReal"/> object into its XML representation.
-        /// </summary>
-        /// <param name="writer">
-        /// an instance of <see cref="XmlWriter"/>
-        /// </param>
-        public override void WriteXml(XmlWriter writer)
-        {
-            base.WriteXml(writer);
+		/// <summary>
+		/// Gets or sets the maximum permissible string length
+		/// </summary>        
+		public int MaxLength { get; set; }
 
-            writer.WriteAttributeString("MAX-LENGTH", this.MaxLength.ToString(NumberFormatInfo.InvariantInfo));
-        }
-    }
+		/// <summary>
+		/// Generates a <see cref="DatatypeDefinitionReal"/> object from its XML representation.
+		/// </summary>
+		/// <param name="reader">
+		/// an instance of <see cref="XmlReader"/>
+		/// </param>
+		public override void ReadXml( XmlReader reader )
+		{
+			base.ReadXml( reader );
+
+			var value = reader.GetAttribute( "MAX-LENGTH" );
+			if ( !string.IsNullOrEmpty( value ) )
+			{
+				this.MaxLength = XmlConvert.ToInt32( value );
+			}
+		}
+
+		/// <summary>
+		/// Converts a <see cref="DatatypeDefinitionReal"/> object into its XML representation.
+		/// </summary>
+		/// <param name="writer">
+		/// an instance of <see cref="XmlWriter"/>
+		/// </param>
+		public override void WriteXml( XmlWriter writer )
+		{
+			base.WriteXml( writer );
+
+			writer.WriteAttributeString( "MAX-LENGTH", XmlConvert.ToString( this.MaxLength ) );
+		}
+	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/ReqIFSharp/pulls) open
- [x] I have verified that I am following the ReqIFSharp [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/ReqIFSharp/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- Fixed wrong serialization/deserialization in datatype definition classes by using XmlConvert instead of int/double Parse.
- Added ReadXml support for MAX-LENGTH attribute in DatatypeDefinitionString class.
- Added ReadXml support for ACCURACY attribute in DatatypeDefinitionReal class.

<!-- Thanks for contributing to ReqIFSharp! -->