### PR TITLE
Add null argument coverage to attribute value tests

### DIFF
--- a/ReqIFSharp.Tests/AttributeValueTests/AttributeValueBooleanTestFixture.cs
+++ b/ReqIFSharp.Tests/AttributeValueTests/AttributeValueBooleanTestFixture.cs
@@ -64,6 +64,18 @@ namespace ReqIFSharp.Tests
         }
 
         [Test]
+        public void Verify_That_Exception_Is_Raised_When_AttributeDefinition_Is_Null()
+        {
+            var attributeValueBoolean = new AttributeValueBoolean();
+            var attributeValue = (AttributeValue)attributeValueBoolean;
+
+            Assert.That(
+                () => attributeValue.AttributeDefinition = null,
+                Throws.Exception.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("attributeDefinition"));
+        }
+
+        [Test]
         public void Verify_That_WriteXml_Without_Definition_Set_Throws_SerializationException()
         {
             using var memoryStream = new MemoryStream();

--- a/ReqIFSharp.Tests/AttributeValueTests/AttributeValueDateTestFixture.cs
+++ b/ReqIFSharp.Tests/AttributeValueTests/AttributeValueDateTestFixture.cs
@@ -64,6 +64,18 @@ namespace ReqIFSharp.Tests
         }
 
         [Test]
+        public void Verify_That_Exception_Is_Raised_When_AttributeDefinition_Is_Null()
+        {
+            var attributeValueDate = new AttributeValueDate();
+            var attributeValue = (AttributeValue)attributeValueDate;
+
+            Assert.That(
+                () => attributeValue.AttributeDefinition = null,
+                Throws.Exception.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("attributeDefinition"));
+        }
+
+        [Test]
         public void Verify_That_WriteXml_Without_Definition_Set_Throws_SerializationException()
         {
             using var memoryStream = new MemoryStream();

--- a/ReqIFSharp.Tests/AttributeValueTests/AttributeValueEnumerationTestFixture.cs
+++ b/ReqIFSharp.Tests/AttributeValueTests/AttributeValueEnumerationTestFixture.cs
@@ -65,6 +65,18 @@ namespace ReqIFSharp.Tests
         }
 
         [Test]
+        public void Verify_That_Exception_Is_Raised_When_AttributeDefinition_Is_Null()
+        {
+            var attributeValueEnumeration = new AttributeValueEnumeration();
+            var attributeValue = (AttributeValue)attributeValueEnumeration;
+
+            Assert.That(
+                () => attributeValue.AttributeDefinition = null,
+                Throws.Exception.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("attributeDefinition"));
+        }
+
+        [Test]
         public void Verify_That_WriteXml_Without_Definition_Set_Throws_SerializationException()
         {
             using var memoryStream = new MemoryStream();

--- a/ReqIFSharp.Tests/AttributeValueTests/AttributeValueIntegerTestFixture.cs
+++ b/ReqIFSharp.Tests/AttributeValueTests/AttributeValueIntegerTestFixture.cs
@@ -64,6 +64,18 @@ namespace ReqIFSharp.Tests
         }
 
         [Test]
+        public void Verify_That_Exception_Is_Raised_When_AttributeDefinition_Is_Null()
+        {
+            var attributeValueInteger = new AttributeValueInteger();
+            var attributeValue = (AttributeValue)attributeValueInteger;
+
+            Assert.That(
+                () => attributeValue.AttributeDefinition = null,
+                Throws.Exception.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("attributeDefinition"));
+        }
+
+        [Test]
         public void Verify_That_WriteXml_Without_Definition_Set_Throws_SerializationException()
         {
             using var memoryStream = new MemoryStream();

--- a/ReqIFSharp.Tests/AttributeValueTests/AttributeValueRealTestFixture.cs
+++ b/ReqIFSharp.Tests/AttributeValueTests/AttributeValueRealTestFixture.cs
@@ -131,6 +131,18 @@ namespace ReqIFSharp.Tests
         }
 
         [Test]
+        public void Verify_That_Exception_Is_Raised_When_AttributeDefinition_Is_Null()
+        {
+            var attributeValueReal = new AttributeValueReal();
+            var attributeValue = (AttributeValue)attributeValueReal;
+
+            Assert.That(
+                () => attributeValue.AttributeDefinition = null,
+                Throws.Exception.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("attributeDefinition"));
+        }
+
+        [Test]
         public void Verify_Convenience_Value_Property()
         {
             var attributeValue = new AttributeValueReal();

--- a/ReqIFSharp.Tests/AttributeValueTests/AttributeValueStringTestFixture.cs
+++ b/ReqIFSharp.Tests/AttributeValueTests/AttributeValueStringTestFixture.cs
@@ -64,6 +64,18 @@ namespace ReqIFSharp.Tests
         }
 
         [Test]
+        public void Verify_That_Exception_Is_Raised_When_AttributeDefinition_Is_Null()
+        {
+            var attributeValueString = new AttributeValueString();
+            var attributeValue = (AttributeValue)attributeValueString;
+
+            Assert.That(
+                () => attributeValue.AttributeDefinition = null,
+                Throws.Exception.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("attributeDefinition"));
+        }
+
+        [Test]
         public void Verify_That_WriteXml_Without_Definition_Set_Throws_SerializationException()
         {
             using var memoryStream = new MemoryStream();

--- a/ReqIFSharp.Tests/AttributeValueTests/AttributeValueXHTMLTestFixture.cs
+++ b/ReqIFSharp.Tests/AttributeValueTests/AttributeValueXHTMLTestFixture.cs
@@ -64,6 +64,18 @@ namespace ReqIFSharp.Tests
         }
 
         [Test]
+        public void Verify_That_Exception_Is_Raised_When_AttributeDefinition_Is_Null()
+        {
+            var attributeValueXhtml = new AttributeValueXHTML();
+            var attributeValue = (AttributeValue)attributeValueXhtml;
+
+            Assert.That(
+                () => attributeValue.AttributeDefinition = null,
+                Throws.Exception.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("attributeDefinition"));
+        }
+
+        [Test]
         public void Verify_That_WriteXml_Without_Definition_Set_Throws_SerializationException()
         {
             using var memoryStream = new MemoryStream();


### PR DESCRIPTION
## Summary
- add unit tests that verify attribute value fixtures throw when attribute definitions are null

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e11a16be0883268beba649e551c3db