### PR TITLE
[Fix] honor CancellationToken in QueryBase64PayloadsAsync; fixes #67

### DIFF
--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecElementWithAttributesExtensionTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecElementWithAttributesExtensionTestFixture.cs
@@ -20,6 +20,7 @@
 
 namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 {
+    using System;
     using System.IO;
     using System.Linq;
     using System.Threading;
@@ -79,6 +80,19 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
             var base64Payload = base64Payloads.Single();
 
             Assert.That(base64Payload.Item2, Does.StartWith("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfgAAACfCAIAAACazFx+AAAAAXNSR0IArs4c6QAA"));
+        }
+
+        [Test]
+        public void Verify_that_QueryBase64PayloadsAsync_honors_cancellation()
+        {
+            var specObject = this.reqIf.CoreContent.SpecObjects.Single(x => x.Identifier == "_3.4.2.2.2_BrLeft_2_BrRight_._BrLeft_f_BrRight_1");
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.That(
+                async () => await specObject.QueryBase64PayloadsAsync(this.reqIFLoaderService, cts.Token),
+                Throws.InstanceOf<OperationCanceledException>());
         }
     }
 }

--- a/ReqIFSharp.Extensions/ReqIFExtensions/SpecElementWithAttributesExtensions.cs
+++ b/ReqIFSharp.Extensions/ReqIFExtensions/SpecElementWithAttributesExtensions.cs
@@ -68,10 +68,13 @@ namespace ReqIFSharp.Extensions.ReqIFExtensions
         /// <param name="reqIfLoaderService">
         /// The <see cref="IReqIFLoaderService"/> that is used to query the payload from the associated reqifz file-stream
         /// </param>
+        /// <param name="token">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>
         /// an <see cref="IEnumerable{String}"/> that contains base64 encoded strings
         /// </returns>
-        public static Task<IEnumerable<Tuple<ExternalObject, string>>> QueryBase64PayloadsAsync(this SpecElementWithAttributes specElementWithAttributes, IReqIFLoaderService reqIfLoaderService)
+        public static Task<IEnumerable<Tuple<ExternalObject, string>>> QueryBase64PayloadsAsync(this SpecElementWithAttributes specElementWithAttributes, IReqIFLoaderService reqIfLoaderService, CancellationToken token = default)
         {
             if (specElementWithAttributes == null)
             {
@@ -83,7 +86,7 @@ namespace ReqIFSharp.Extensions.ReqIFExtensions
                 throw new ArgumentNullException(nameof(reqIfLoaderService));
             }
 
-            return QueryBase64PayloadsInternalAsync(specElementWithAttributes, reqIfLoaderService);
+            return QueryBase64PayloadsInternalAsync(specElementWithAttributes, reqIfLoaderService, token);
         }
 
         /// <summary>
@@ -95,20 +98,21 @@ namespace ReqIFSharp.Extensions.ReqIFExtensions
         /// <param name="reqIfLoaderService">
         /// The <see cref="IReqIFLoaderService"/> that is used to query the payload from the associated reqifz file-stream
         /// </param>
+        /// <param name="token">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>
         /// an <see cref="IEnumerable{String}"/> that contains base64 encoded strings
         /// </returns>
-        private static async Task<IEnumerable<Tuple<ExternalObject, string>>> QueryBase64PayloadsInternalAsync(this SpecElementWithAttributes specElementWithAttributes, IReqIFLoaderService reqIfLoaderService)
+        private static async Task<IEnumerable<Tuple<ExternalObject, string>>> QueryBase64PayloadsInternalAsync(this SpecElementWithAttributes specElementWithAttributes, IReqIFLoaderService reqIfLoaderService, CancellationToken token)
         {
             var result = new List<Tuple<ExternalObject, string>>();
-
-            using var cts = new CancellationTokenSource();
 
             foreach (var specObjectValue in specElementWithAttributes.Values.OfType<AttributeValueXHTML>())
             {
                 foreach (var externalObject in specObjectValue.ExternalObjects)
                 {
-                    var payload = await reqIfLoaderService.QueryDataAsync(externalObject, cts.Token);
+                    var payload = await reqIfLoaderService.QueryDataAsync(externalObject, token);
                     result.Add(new Tuple<ExternalObject, string>(externalObject, payload));
                 }
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/ReqIFSharp/pulls) open
- [x] I have verified that I am following the ReqIFSharp [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/ReqIFSharp/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
 Add a CancellationToken parameter to QueryBase64PayloadsAsync and flow it through to IReqIFLoaderService.QueryDataAsync, removing the orphaned CancellationTokenSource that made cancellation impossible. Adds a cancellation regression test.

<!-- Thanks for contributing to ReqIFSharp! -->