### PR TITLE
[Implement] remove trailing space from ExternalObject.CreateUrl; fixes #68

### DIFF
--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/ExternalObjectExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/ExternalObjectExtensionsTestFixture.cs
@@ -79,7 +79,7 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
             };
 
             var expectedBase64Uri = Convert.ToBase64String(Encoding.UTF8.GetBytes(externalObject.Uri));
-            var expectedUrl = $"/reqif/{header.Identifier}/externalobject/{expectedBase64Uri} ";
+            var expectedUrl = $"/reqif/{header.Identifier}/externalobject/{expectedBase64Uri}";
 
             Assert.That(externalObject.CreateUrl(), Is.EqualTo(expectedUrl));
         }

--- a/ReqIFSharp.Extensions/ReqIFExtensions/ExternalObjectExtensions.cs
+++ b/ReqIFSharp.Extensions/ReqIFExtensions/ExternalObjectExtensions.cs
@@ -48,7 +48,7 @@ namespace ReqIFSharp.Extensions.ReqIFExtensions
 
             var url = new StringBuilder();
             url.Append($"/reqif/{externalObject.Owner.SpecElAt.ReqIFContent.DocumentRoot.TheHeader.Identifier}");
-            url.Append($"/externalobject/{externalObject.Uri.Base64Encode()} ");
+            url.Append($"/externalobject/{externalObject.Uri.Base64Encode()}");
 
             return url.ToString();
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/ReqIFSharp/pulls) open
- [x] I have verified that I am following the ReqIFSharp [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/ReqIFSharp/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
CreateUrl appended a stray space after the base64 URI, producing an invalid web-app URL. Drop the space and correct the xisting test expectation, which had codified the bug.


<!-- Thanks for contributing to ReqIFSharp! -->