### PR TITLE
[Implement] dispose manifest resource stream in GetSchemaFromResource; fixes #69

### DIFF
--- a/ReqIFSharp/ReqIFDeserializer.cs
+++ b/ReqIFSharp/ReqIFDeserializer.cs
@@ -538,14 +538,15 @@ namespace ReqIFSharp
             var @namespace = type.Namespace;
             var reqifSchemaResourceName = $"{@namespace}.Resources.{resourceName}";
 
-            var stream = a.GetManifestResourceStream(reqifSchemaResourceName);
-
-            if (stream == null)
+            using (var stream = a.GetManifestResourceStream(reqifSchemaResourceName))
             {
-                throw new MissingManifestResourceException($"The {reqifSchemaResourceName} resource could not be found");
+                if (stream == null)
+                {
+                    throw new MissingManifestResourceException($"The {reqifSchemaResourceName} resource could not be found");
+                }
+
+                return XmlSchema.Read(stream, validationEventHandler);
             }
-            
-            return XmlSchema.Read(stream, validationEventHandler);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/ReqIFSharp/pulls) open
- [x] I have verified that I am following the ReqIFSharp [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/ReqIFSharp/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

- ReqIFSharp/ReqIFDeserializer.cs (GetSchemaFromResource) — the manifest resource stream from GetManifestResourceStream is now wrapped in a using block, so it's disposed on all paths. XmlSchema.Read fully materializes the schema into the returned XmlSchema before the stream is disposed, so behavior is unchanged. The null    check (→ MissingManifestResourceException) is preserved inside the block

<!-- Thanks for contributing to ReqIFSharp! -->