### PR TITLE
[Implement] deterministic builds and CI pack for reproducible packages; fixes #71

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           cat RELEASE_NOTES.md
 
       - name: Pack
-        run: dotnet pack -c Release -o ReleaseBuilds ReqIFSharp.sln
+        run: dotnet pack -c Release -o ReleaseBuilds ReqIFSharp.sln /p:ContinuousIntegrationBuild=true
 
       - name: Push to NuGet
         env:

--- a/ReqIFSharp.Extensions/ReqIFSharp.Extensions.csproj
+++ b/ReqIFSharp.Extensions/ReqIFSharp.Extensions.csproj
@@ -4,6 +4,7 @@
       <TargetFramework>netstandard2.0</TargetFramework>
       <Version>5.0.5</Version>
       <LangVersion>12.0</LangVersion>
+      <Deterministic>true</Deterministic>
       <Title>ReqIFSharp.Extensions</Title>
       <Description>A .NET library that provides extenions and services to operate on ReqIF documents.</Description>
       <PackageId>ReqIFSharp.Extensions</PackageId>

--- a/ReqIFSharp/ReqIFSharp.csproj
+++ b/ReqIFSharp/ReqIFSharp.csproj
@@ -6,6 +6,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <Version>10.0.5</Version>
         <LangVersion>12.0</LangVersion>
+        <Deterministic>true</Deterministic>
         <Title>ReqIFSharp</Title>
         <Description>A .NET library to deserialize (read) and serialize (write) OMG ReqIF documents.</Description>
         <PackageId>ReqIFSharp</PackageId>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/ReqIFSharp/pulls) open
- [x] I have verified that I am following the ReqIFSharp [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/ReqIFSharp/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Makes the published NuGet packages reproducible (closes #71). Adds <Deterministic>true</Deterministic> to both shipping library projects (ReqIFSharp, ReqIFSharp.Extensions) and passes /p:ContinuousIntegrationBuild=true to the release dotnet pack step, matching the flag already used in the CodeQuality and nuget-reference-check workflows. Build/packaging-only change — no runtime behavior change; full test suite (362) green and dotnet pack verified to embed no machine-absolute source paths.


<!-- Thanks for contributing to ReqIFSharp! -->