### PR TITLE
[Update] lower Microsoft.Extensions.Logging.Abstractions floor to 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ The packages are available on Nuget:
 - [ReqIFSharp](https://www.nuget.org/packages/ReqIFSharp): ![NuGet Version](https://img.shields.io/nuget/v/ReqIFSharp)
 - [ReqIFSharp.Extensions](https://www.nuget.org/packages/ReqIFSharp.Extensions): ![NuGet Version](https://img.shields.io/nuget/v/ReqIFSharp.Extensions)
 
+## Dependencies
+
+`ReqIFSharp` targets `netstandard2.0` and has a single runtime dependency: `Microsoft.Extensions.Logging.Abstractions`. Its version is **deliberately floored at `6.0.0`** - the lowest version that exposes every logging API the library uses. Because a NuGet package reference is a *minimum*, a low floor keeps the library broadly consumable instead of forcing everyone onto the latest major.
+
+**Using ReqIFSharp from .NET 8/10 (or any modern app)?** You don't have to do anything - NuGet automatically floats the dependency up to the version your application already uses (e.g. `Microsoft.Extensions.Logging.Abstractions 10.x` on .NET 10). If you want to be explicit, simply add a direct reference in your own project to the version that matches your runtime:
+
+```xml
+<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+```
+
+This pins the resolved version in your application without ReqIFSharp imposing it on consumers who are still on older lines.
+
 ## Build Status
 
 GitHub actions are used to build and test the library

--- a/ReqIFSharp/ReqIFSharp.csproj
+++ b/ReqIFSharp/ReqIFSharp.csproj
@@ -90,7 +90,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+        <!--
+            The version is deliberately floored at 6.0.0 (the minimum that contains every API we use:
+            ILogger/ILoggerFactory, CreateLogger<T>, NullLogger<T> and the Log* message-template
+            extensions). A PackageReference version is a transitive *minimum*, so keeping it low lets
+            consumers - especially those still on older Microsoft.Extensions.* lines - resolve the
+            package without being forced onto the latest major. NuGet will float consumers up to a
+            higher version when their own graph requires it. Do not raise this floor without a real
+            API need.
+        -->
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

The core `ReqIFSharp` library pinned `Microsoft.Extensions.Logging.Abstractions` at `10.0.8`, but only uses logging APIs that have existed since `6.0.0` (`ILogger`/`ILoggerFactory`, `CreateLogger<T>`, `NullLogger<T>`, and the `Log*` message-template extensions).

A `PackageReference` version is a transitive **minimum**, so the high floor forced every consumer onto the `10.x` line — at odds with the broad reach the `netstandard2.0` target is meant to provide. This PR lowers the floor to `6.0.0` while letting NuGet float consumers up when their own graph requires a newer version.

## Changes

- `ReqIFSharp/ReqIFSharp.csproj` — floor `Microsoft.Extensions.Logging.Abstractions` at `6.0.0`, with an explanatory comment so the low floor isn't "fixed" later by mistake.
- `README.md` — new **Dependencies** section explaining the floor and how .NET 8/10 consumers can float or explicitly pin the dependency.

## Verification

- `dotnet build ReqIFSharp/ReqIFSharp.csproj -c Release` — succeeds, 0 warnings / 0 errors on `netstandard2.0`.
- `dotnet list package` confirms the dependency resolves at `6.0.0`.
- No source/code changes; build- and test-only dependencies are unaffected (the `net10.0` test projects still pull `10.x` transitively).