### PR TITLE
[Add] uml-like metadata decorators on the model; fixes #27

### DIFF
--- a/ReqIFSharp.Tests/Decorators/ClassAttributeTestFixture.cs
+++ b/ReqIFSharp.Tests/Decorators/ClassAttributeTestFixture.cs
@@ -1,0 +1,64 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="ClassAttributeTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ReqIFSharp.Tests.Decorators
+{
+    using NUnit.Framework;
+
+    using ReqIFSharp;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ClassAttribute"/> class
+    /// </summary>
+    [TestFixture]
+    public class ClassAttributeTestFixture
+    {
+        [Test]
+        public void Verify_that_default_constructor_values_are_as_expected()
+        {
+            var classAttribute = new ClassAttribute();
+
+            Assert.That(classAttribute.Name, Is.EqualTo(string.Empty));
+            Assert.That(classAttribute.IsAbstract, Is.False);
+        }
+
+        [Test]
+        public void Verify_that_constructor_sets_properties_as_expected()
+        {
+            var classAttribute = new ClassAttribute("SPEC-OBJECT", true);
+
+            Assert.That(classAttribute.Name, Is.EqualTo("SPEC-OBJECT"));
+            Assert.That(classAttribute.IsAbstract, Is.True);
+        }
+
+        [Test]
+        public void Verify_that_properties_can_be_set()
+        {
+            var classAttribute = new ClassAttribute
+            {
+                Name = "SPEC-RELATION",
+                IsAbstract = true
+            };
+
+            Assert.That(classAttribute.Name, Is.EqualTo("SPEC-RELATION"));
+            Assert.That(classAttribute.IsAbstract, Is.True);
+        }
+    }
+}

--- a/ReqIFSharp.Tests/Decorators/ModelMetadataTestFixture.cs
+++ b/ReqIFSharp.Tests/Decorators/ModelMetadataTestFixture.cs
@@ -29,13 +29,10 @@ namespace ReqIFSharp.Tests.Decorators
 
     using ReqIFSharp;
 
-    // ReqIFSharp.PropertyAttribute collides with NUnit.Framework.PropertyAttribute; alias to the model decorator.
-    using PropertyAttribute = ReqIFSharp.PropertyAttribute;
-
     /// <summary>
     /// Reflection-driven completeness guard that verifies every model class and metamodel property
     /// in the <see cref="ReqIFSharp"/> assembly is decorated with the <see cref="ClassAttribute"/>
-    /// and <see cref="PropertyAttribute"/> metadata decorators. When a new model class or property
+    /// and <see cref="ReqIfPropertyAttribute"/> metadata decorators. When a new model class or property
     /// is added, this fixture fails until the decorators are applied (or the property is added to the
     /// documented exclusion list of infrastructure / back-reference members).
     /// </summary>
@@ -44,7 +41,7 @@ namespace ReqIFSharp.Tests.Decorators
     {
         /// <summary>
         /// Names of properties that are NOT part of the ReqIF metamodel and therefore intentionally
-        /// carry no <see cref="PropertyAttribute"/>: container back-references, owner links and
+        /// carry no <see cref="ReqIfPropertyAttribute"/>: container back-references, owner links and
         /// programming-convenience accessors.
         /// </summary>
         private static readonly HashSet<string> ExcludedPropertyNames = new HashSet<string>
@@ -91,7 +88,7 @@ namespace ReqIFSharp.Tests.Decorators
 
         /// <summary>
         /// Returns the public, instance properties declared directly on <paramref name="type"/> that
-        /// are expected to carry a <see cref="PropertyAttribute"/> (i.e. metamodel features), filtering
+        /// are expected to carry a <see cref="ReqIfPropertyAttribute"/> (i.e. metamodel features), filtering
         /// out the documented infrastructure / back-reference exclusions. The <c>Definition</c> property
         /// IS a metamodel reference and is therefore kept even though it appears in the lookup set above
         /// only for documentation - it is removed from the exclusion set here.
@@ -130,7 +127,7 @@ namespace ReqIFSharp.Tests.Decorators
         }
 
         [Test]
-        public void Verify_that_every_metamodel_property_is_decorated_with_PropertyAttribute()
+        public void Verify_that_every_metamodel_property_is_decorated_with_ReqIfPropertyAttribute()
         {
             var offenders = new List<string>();
 
@@ -138,7 +135,7 @@ namespace ReqIFSharp.Tests.Decorators
             {
                 foreach (var property in MetamodelProperties(type))
                 {
-                    if (property.GetCustomAttribute<PropertyAttribute>() == null)
+                    if (property.GetCustomAttribute<ReqIfPropertyAttribute>() == null)
                     {
                         offenders.Add($"{type.Name}.{property.Name}");
                     }
@@ -150,13 +147,13 @@ namespace ReqIFSharp.Tests.Decorators
         }
 
         [Test]
-        public void Verify_that_every_PropertyAttribute_has_consistent_multiplicity()
+        public void Verify_that_every_ReqIfPropertyAttribute_has_consistent_multiplicity()
         {
             foreach (var type in ModelTypes())
             {
                 foreach (var property in MetamodelProperties(type))
                 {
-                    var propertyAttribute = property.GetCustomAttribute<PropertyAttribute>();
+                    var propertyAttribute = property.GetCustomAttribute<ReqIfPropertyAttribute>();
 
                     if (propertyAttribute == null)
                     {
@@ -189,7 +186,7 @@ namespace ReqIFSharp.Tests.Decorators
             var property = type.GetProperty(propertyName);
             Assert.That(property, Is.Not.Null, $"{type.Name}.{propertyName} does not exist.");
 
-            var propertyAttribute = property.GetCustomAttribute<PropertyAttribute>();
+            var propertyAttribute = property.GetCustomAttribute<ReqIfPropertyAttribute>();
             Assert.That(propertyAttribute, Is.Not.Null, $"{type.Name}.{propertyName} is missing the [Property] decorator.");
 
             Assert.Multiple(() =>

--- a/ReqIFSharp.Tests/Decorators/ModelMetadataTestFixture.cs
+++ b/ReqIFSharp.Tests/Decorators/ModelMetadataTestFixture.cs
@@ -31,7 +31,7 @@ namespace ReqIFSharp.Tests.Decorators
 
     /// <summary>
     /// Reflection-driven completeness guard that verifies every model class and metamodel property
-    /// in the <see cref="ReqIFSharp"/> assembly is decorated with the <see cref="ClassAttribute"/>
+    /// in the <see cref="ReqIFSharp"/> assembly is decorated with the <see cref="ReqIfClassAttribute"/>
     /// and <see cref="ReqIfPropertyAttribute"/> metadata decorators. When a new model class or property
     /// is added, this fixture fails until the decorators are applied (or the property is added to the
     /// documented exclusion list of infrastructure / back-reference members).
@@ -101,10 +101,10 @@ namespace ReqIFSharp.Tests.Decorators
         }
 
         [Test]
-        public void Verify_that_every_model_class_is_decorated_with_ClassAttribute()
+        public void Verify_that_every_model_class_is_decorated_with_ReqIfClassAttribute()
         {
             var offenders = ModelTypes()
-                .Where(t => t.GetCustomAttribute<ClassAttribute>() == null)
+                .Where(t => t.GetCustomAttribute<ReqIfClassAttribute>() == null)
                 .Select(t => t.Name)
                 .ToList();
 
@@ -113,11 +113,11 @@ namespace ReqIFSharp.Tests.Decorators
         }
 
         [Test]
-        public void Verify_that_ClassAttribute_IsAbstract_matches_the_type()
+        public void Verify_that_ReqIfClassAttribute_IsAbstract_matches_the_type()
         {
             foreach (var type in ModelTypes())
             {
-                var classAttribute = type.GetCustomAttribute<ClassAttribute>();
+                var classAttribute = type.GetCustomAttribute<ReqIfClassAttribute>();
 
                 Assert.That(classAttribute, Is.Not.Null, $"{type.Name} is missing the [Class] decorator.");
                 Assert.That(classAttribute.IsAbstract, Is.EqualTo(type.IsAbstract),

--- a/ReqIFSharp.Tests/Decorators/ModelMetadataTestFixture.cs
+++ b/ReqIFSharp.Tests/Decorators/ModelMetadataTestFixture.cs
@@ -1,0 +1,203 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="ModelMetadataTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ReqIFSharp.Tests.Decorators
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using NUnit.Framework;
+
+    using ReqIFSharp;
+
+    // ReqIFSharp.PropertyAttribute collides with NUnit.Framework.PropertyAttribute; alias to the model decorator.
+    using PropertyAttribute = ReqIFSharp.PropertyAttribute;
+
+    /// <summary>
+    /// Reflection-driven completeness guard that verifies every model class and metamodel property
+    /// in the <see cref="ReqIFSharp"/> assembly is decorated with the <see cref="ClassAttribute"/>
+    /// and <see cref="PropertyAttribute"/> metadata decorators. When a new model class or property
+    /// is added, this fixture fails until the decorators are applied (or the property is added to the
+    /// documented exclusion list of infrastructure / back-reference members).
+    /// </summary>
+    [TestFixture]
+    public class ModelMetadataTestFixture
+    {
+        /// <summary>
+        /// Names of properties that are NOT part of the ReqIF metamodel and therefore intentionally
+        /// carry no <see cref="PropertyAttribute"/>: container back-references, owner links and
+        /// programming-convenience accessors.
+        /// </summary>
+        private static readonly HashSet<string> ExcludedPropertyNames = new HashSet<string>
+        {
+            "ObjectValue",       // convenience accessor that aliases TheValue / Values
+            "DatatypeDefinition", // AttributeDefinition base accessor that aliases the concrete Type
+            "AttributeDefinition", // AttributeValue base accessor that aliases the concrete Definition
+            "ExternalObjects",   // derived from the parsed XHTML content
+            "OwningDefinition",  // back-reference to the owning AttributeDefinition
+            "Definition",        // see note below - kept, handled explicitly (NOT excluded)
+            "SpecElAt",          // back-reference to the owning SpecElementWithAttributes
+            "SpecType",          // AttributeDefinition back-reference to its owning SpecType
+            "ReqIFContent",      // back-reference to the owning ReqIFContent
+            "ReqIfContent",      // back-reference (SpecHierarchy casing variant)
+            "DocumentRoot",      // back-reference to the owning ReqIF
+            "CoreContent",       // RelationGroup back-reference to the owning ReqIFContent
+            "Root",              // SpecHierarchy back-reference to the owning Specification
+            "Container",         // SpecHierarchy back-reference to the parent SpecHierarchy
+            "DataTpeDefEnum",    // EnumValue back-reference to the owning DatatypeDefinitionEnumeration
+            "EnumValue",         // EmbeddedValue back-reference to the owning EnumValue
+            "Owner",             // ExternalObject back-reference to the owning AttributeValueXHTML
+            "Ident"              // AlternativeId back-reference to the owning Identifiable
+        };
+
+        /// <summary>
+        /// Returns every model class in the <see cref="ReqIFSharp"/> assembly. A model class is one
+        /// that derives from <see cref="Identifiable"/> or <see cref="AttributeValue"/>, or is one of
+        /// the remaining stand-alone model classes.
+        /// </summary>
+        private static IEnumerable<Type> ModelTypes()
+        {
+            var standalone = new[]
+            {
+                typeof(ReqIF), typeof(ReqIFContent), typeof(ReqIFHeader), typeof(ReqIFToolExtension),
+                typeof(AlternativeId), typeof(EmbeddedValue), typeof(ExternalObject)
+            };
+
+            return typeof(Identifiable).Assembly.GetTypes()
+                .Where(t => t.IsClass
+                            && (typeof(Identifiable).IsAssignableFrom(t)
+                                || typeof(AttributeValue).IsAssignableFrom(t)
+                                || standalone.Contains(t)));
+        }
+
+        /// <summary>
+        /// Returns the public, instance properties declared directly on <paramref name="type"/> that
+        /// are expected to carry a <see cref="PropertyAttribute"/> (i.e. metamodel features), filtering
+        /// out the documented infrastructure / back-reference exclusions. The <c>Definition</c> property
+        /// IS a metamodel reference and is therefore kept even though it appears in the lookup set above
+        /// only for documentation - it is removed from the exclusion set here.
+        /// </summary>
+        private static IEnumerable<PropertyInfo> MetamodelProperties(Type type)
+        {
+            return type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(p => p.GetMethod != null && p.GetMethod.IsPublic)
+                .Where(p => p.Name == "Definition" || !ExcludedPropertyNames.Contains(p.Name));
+        }
+
+        [Test]
+        public void Verify_that_every_model_class_is_decorated_with_ClassAttribute()
+        {
+            var offenders = ModelTypes()
+                .Where(t => t.GetCustomAttribute<ClassAttribute>() == null)
+                .Select(t => t.Name)
+                .ToList();
+
+            Assert.That(offenders, Is.Empty,
+                $"The following model classes are missing the [Class] decorator: {string.Join(", ", offenders)}");
+        }
+
+        [Test]
+        public void Verify_that_ClassAttribute_IsAbstract_matches_the_type()
+        {
+            foreach (var type in ModelTypes())
+            {
+                var classAttribute = type.GetCustomAttribute<ClassAttribute>();
+
+                Assert.That(classAttribute, Is.Not.Null, $"{type.Name} is missing the [Class] decorator.");
+                Assert.That(classAttribute.IsAbstract, Is.EqualTo(type.IsAbstract),
+                    $"[Class].IsAbstract on {type.Name} does not match the type's abstractness.");
+                Assert.That(classAttribute.Name, Is.Not.Empty, $"[Class].Name on {type.Name} should not be empty.");
+            }
+        }
+
+        [Test]
+        public void Verify_that_every_metamodel_property_is_decorated_with_PropertyAttribute()
+        {
+            var offenders = new List<string>();
+
+            foreach (var type in ModelTypes())
+            {
+                foreach (var property in MetamodelProperties(type))
+                {
+                    if (property.GetCustomAttribute<PropertyAttribute>() == null)
+                    {
+                        offenders.Add($"{type.Name}.{property.Name}");
+                    }
+                }
+            }
+
+            Assert.That(offenders, Is.Empty,
+                $"The following metamodel properties are missing the [Property] decorator: {string.Join(", ", offenders)}");
+        }
+
+        [Test]
+        public void Verify_that_every_PropertyAttribute_has_consistent_multiplicity()
+        {
+            foreach (var type in ModelTypes())
+            {
+                foreach (var property in MetamodelProperties(type))
+                {
+                    var propertyAttribute = property.GetCustomAttribute<PropertyAttribute>();
+
+                    if (propertyAttribute == null)
+                    {
+                        continue;
+                    }
+
+                    Assert.That(propertyAttribute.LowerValue, Is.GreaterThanOrEqualTo(0),
+                        $"{type.Name}.{property.Name} has a negative lower bound.");
+                    Assert.That(propertyAttribute.UpperValue, Is.GreaterThanOrEqualTo(1),
+                        $"{type.Name}.{property.Name} has an upper bound below 1.");
+                    Assert.That(propertyAttribute.UpperValue, Is.GreaterThanOrEqualTo(propertyAttribute.LowerValue),
+                        $"{type.Name}.{property.Name} has an upper bound below its lower bound.");
+                }
+            }
+        }
+
+        [Test]
+        public void Verify_known_property_metadata_spot_checks()
+        {
+            AssertProperty(typeof(SpecObject), nameof(SpecObject.Type), AggregationKind.None, 1, 1);
+            AssertProperty(typeof(ReqIFContent), nameof(ReqIFContent.SpecObjects), AggregationKind.Composite, 0, int.MaxValue);
+            AssertProperty(typeof(Identifiable), nameof(Identifiable.Identifier), AggregationKind.None, 1, 1);
+            AssertProperty(typeof(Identifiable), nameof(Identifiable.AlternativeId), AggregationKind.Composite, 0, 1);
+            AssertProperty(typeof(AttributeDefinitionEnumeration), nameof(AttributeDefinitionEnumeration.IsMultiValued), AggregationKind.None, 1, 1);
+            AssertProperty(typeof(DatatypeDefinitionEnumeration), nameof(DatatypeDefinitionEnumeration.SpecifiedValues), AggregationKind.Composite, 0, int.MaxValue);
+        }
+
+        private static void AssertProperty(Type type, string propertyName, AggregationKind aggregation, int lower, int upper)
+        {
+            var property = type.GetProperty(propertyName);
+            Assert.That(property, Is.Not.Null, $"{type.Name}.{propertyName} does not exist.");
+
+            var propertyAttribute = property.GetCustomAttribute<PropertyAttribute>();
+            Assert.That(propertyAttribute, Is.Not.Null, $"{type.Name}.{propertyName} is missing the [Property] decorator.");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(propertyAttribute.Aggregation, Is.EqualTo(aggregation), $"{type.Name}.{propertyName} aggregation");
+                Assert.That(propertyAttribute.LowerValue, Is.EqualTo(lower), $"{type.Name}.{propertyName} lower bound");
+                Assert.That(propertyAttribute.UpperValue, Is.EqualTo(upper), $"{type.Name}.{propertyName} upper bound");
+            });
+        }
+    }
+}

--- a/ReqIFSharp.Tests/Decorators/PropertyAttributeTestFixture.cs
+++ b/ReqIFSharp.Tests/Decorators/PropertyAttributeTestFixture.cs
@@ -1,0 +1,77 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="PropertyAttributeTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ReqIFSharp.Tests.Decorators
+{
+    using NUnit.Framework;
+
+    using ReqIFSharp;
+
+    // ReqIFSharp.PropertyAttribute collides with NUnit.Framework.PropertyAttribute; alias to the model decorator.
+    using PropertyAttribute = ReqIFSharp.PropertyAttribute;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="PropertyAttribute"/> class
+    /// </summary>
+    [TestFixture]
+    public class PropertyAttributeTestFixture
+    {
+        [Test]
+        public void Verify_that_default_constructor_values_are_as_expected()
+        {
+            var propertyAttribute = new PropertyAttribute();
+
+            Assert.That(propertyAttribute.Aggregation, Is.EqualTo(AggregationKind.None));
+            Assert.That(propertyAttribute.LowerValue, Is.EqualTo(1));
+            Assert.That(propertyAttribute.UpperValue, Is.EqualTo(1));
+            Assert.That(propertyAttribute.IsOrdered, Is.False);
+            Assert.That(propertyAttribute.IsReadOnly, Is.False);
+            Assert.That(propertyAttribute.IsDerived, Is.False);
+            Assert.That(propertyAttribute.IsDerivedUnion, Is.False);
+            Assert.That(propertyAttribute.IsUnique, Is.True);
+            Assert.That(propertyAttribute.DefaultValue, Is.Null);
+        }
+
+        [Test]
+        public void Verify_that_constructor_sets_properties_as_expected()
+        {
+            var propertyAttribute = new PropertyAttribute(
+                aggregation: AggregationKind.Composite,
+                lowerValue: 0,
+                upperValue: int.MaxValue,
+                isOrdered: true,
+                isReadOnly: true,
+                isDerived: true,
+                isDerivedUnion: true,
+                isUnique: false,
+                defaultValue: "default");
+
+            Assert.That(propertyAttribute.Aggregation, Is.EqualTo(AggregationKind.Composite));
+            Assert.That(propertyAttribute.LowerValue, Is.EqualTo(0));
+            Assert.That(propertyAttribute.UpperValue, Is.EqualTo(int.MaxValue));
+            Assert.That(propertyAttribute.IsOrdered, Is.True);
+            Assert.That(propertyAttribute.IsReadOnly, Is.True);
+            Assert.That(propertyAttribute.IsDerived, Is.True);
+            Assert.That(propertyAttribute.IsDerivedUnion, Is.True);
+            Assert.That(propertyAttribute.IsUnique, Is.False);
+            Assert.That(propertyAttribute.DefaultValue, Is.EqualTo("default"));
+        }
+    }
+}

--- a/ReqIFSharp.Tests/Decorators/ReqIfClassAttributeTestFixture.cs
+++ b/ReqIFSharp.Tests/Decorators/ReqIfClassAttributeTestFixture.cs
@@ -1,5 +1,5 @@
 // -------------------------------------------------------------------------------------------------
-// <copyright file="ClassAttributeTestFixture.cs" company="Starion Group S.A.">
+// <copyright file="ReqIfClassAttributeTestFixture.cs" company="Starion Group S.A.">
 //
 //   Copyright 2017-2026 Starion Group S.A.
 //
@@ -25,15 +25,15 @@ namespace ReqIFSharp.Tests.Decorators
     using ReqIFSharp;
 
     /// <summary>
-    /// Suite of tests for the <see cref="ClassAttribute"/> class
+    /// Suite of tests for the <see cref="ReqIfClassAttribute"/> class
     /// </summary>
     [TestFixture]
-    public class ClassAttributeTestFixture
+    public class ReqIfClassAttributeTestFixture
     {
         [Test]
         public void Verify_that_default_constructor_values_are_as_expected()
         {
-            var classAttribute = new ClassAttribute();
+            var classAttribute = new ReqIfClassAttribute();
 
             Assert.That(classAttribute.Name, Is.EqualTo(string.Empty));
             Assert.That(classAttribute.IsAbstract, Is.False);
@@ -42,7 +42,7 @@ namespace ReqIFSharp.Tests.Decorators
         [Test]
         public void Verify_that_constructor_sets_properties_as_expected()
         {
-            var classAttribute = new ClassAttribute("SPEC-OBJECT", true);
+            var classAttribute = new ReqIfClassAttribute("SPEC-OBJECT", true);
 
             Assert.That(classAttribute.Name, Is.EqualTo("SPEC-OBJECT"));
             Assert.That(classAttribute.IsAbstract, Is.True);
@@ -51,7 +51,7 @@ namespace ReqIFSharp.Tests.Decorators
         [Test]
         public void Verify_that_properties_can_be_set()
         {
-            var classAttribute = new ClassAttribute
+            var classAttribute = new ReqIfClassAttribute
             {
                 Name = "SPEC-RELATION",
                 IsAbstract = true

--- a/ReqIFSharp.Tests/Decorators/ReqIfPropertyAttributeTestFixture.cs
+++ b/ReqIFSharp.Tests/Decorators/ReqIfPropertyAttributeTestFixture.cs
@@ -24,19 +24,16 @@ namespace ReqIFSharp.Tests.Decorators
 
     using ReqIFSharp;
 
-    // ReqIFSharp.PropertyAttribute collides with NUnit.Framework.PropertyAttribute; alias to the model decorator.
-    using PropertyAttribute = ReqIFSharp.PropertyAttribute;
-
     /// <summary>
-    /// Suite of tests for the <see cref="PropertyAttribute"/> class
+    /// Suite of tests for the <see cref="ReqIfPropertyAttribute"/> class
     /// </summary>
     [TestFixture]
-    public class PropertyAttributeTestFixture
+    public class ReqIfPropertyAttributeTestFixture
     {
         [Test]
         public void Verify_that_default_constructor_values_are_as_expected()
         {
-            var propertyAttribute = new PropertyAttribute();
+            var propertyAttribute = new ReqIfPropertyAttribute();
 
             Assert.That(propertyAttribute.Aggregation, Is.EqualTo(AggregationKind.None));
             Assert.That(propertyAttribute.LowerValue, Is.EqualTo(1));
@@ -52,7 +49,7 @@ namespace ReqIFSharp.Tests.Decorators
         [Test]
         public void Verify_that_constructor_sets_properties_as_expected()
         {
-            var propertyAttribute = new PropertyAttribute(
+            var propertyAttribute = new ReqIfPropertyAttribute(
                 aggregation: AggregationKind.Composite,
                 lowerValue: 0,
                 upperValue: int.MaxValue,

--- a/ReqIFSharp/AccessControlledElement.cs
+++ b/ReqIFSharp/AccessControlledElement.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="AccessControlledElement"/> is the base class for classes that may restrict user access to their information.
     /// </summary>
-    [Class(name: "ACCESS-CONTROLLED-ELEMENT", isAbstract: true)]
+    [ReqIfClass(name: "ACCESS-CONTROLLED-ELEMENT", isAbstract: true)]
     public abstract class AccessControlledElement : Identifiable
     {
         /// <summary>

--- a/ReqIFSharp/AccessControlledElement.cs
+++ b/ReqIFSharp/AccessControlledElement.cs
@@ -67,7 +67,7 @@ namespace ReqIFSharp
         /// True means that the element’s contents may be modified by the user of a tool containing the element.
         /// False or leaving isEditable out means that the element is read-only to the user of a tool containing the element.
         /// </remarks>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public bool IsEditable { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AccessControlledElement.cs
+++ b/ReqIFSharp/AccessControlledElement.cs
@@ -67,7 +67,7 @@ namespace ReqIFSharp
         /// True means that the element’s contents may be modified by the user of a tool containing the element.
         /// False or leaving isEditable out means that the element is read-only to the user of a tool containing the element.
         /// </remarks>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public bool IsEditable { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AccessControlledElement.cs
+++ b/ReqIFSharp/AccessControlledElement.cs
@@ -32,6 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="AccessControlledElement"/> is the base class for classes that may restrict user access to their information.
     /// </summary>
+    [Class(name: "ACCESS-CONTROLLED-ELEMENT", isAbstract: true)]
     public abstract class AccessControlledElement : Identifiable
     {
         /// <summary>
@@ -66,6 +67,7 @@ namespace ReqIFSharp
         /// True means that the element’s contents may be modified by the user of a tool containing the element.
         /// False or leaving isEditable out means that the element is read-only to the user of a tool containing the element.
         /// </remarks>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public bool IsEditable { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AlternativeID.cs
+++ b/ReqIFSharp/AlternativeID.cs
@@ -28,7 +28,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AlternativeId"/> class is to provide an alternative, tool-specific identification.
     /// </summary>
-    [Class(name: "ALTERNATIVE-ID")]
+    [ReqIfClass(name: "ALTERNATIVE-ID")]
     public class AlternativeId
     {
         /// <summary>

--- a/ReqIFSharp/AlternativeID.cs
+++ b/ReqIFSharp/AlternativeID.cs
@@ -28,7 +28,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AlternativeId"/> class is to provide an alternative, tool-specific identification.
     /// </summary>
-    [ReqIfClass(name: "ALTERNATIVE-ID")]
+    [ReqIfClass(name: "ALTERNATIVE-ID", isAbstract: false)]
     public class AlternativeId
     {
         /// <summary>
@@ -53,7 +53,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the optional alternative identifier, which may be a requirements management tool identifier or <see cref="ReqIF"/> tool identifier
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string Identifier { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AlternativeID.cs
+++ b/ReqIFSharp/AlternativeID.cs
@@ -28,6 +28,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AlternativeId"/> class is to provide an alternative, tool-specific identification.
     /// </summary>
+    [Class(name: "ALTERNATIVE-ID")]
     public class AlternativeId
     {
         /// <summary>
@@ -52,6 +53,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the optional alternative identifier, which may be a requirements management tool identifier or <see cref="ReqIF"/> tool identifier
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string Identifier { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AlternativeID.cs
+++ b/ReqIFSharp/AlternativeID.cs
@@ -53,7 +53,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the optional alternative identifier, which may be a requirements management tool identifier or <see cref="ReqIF"/> tool identifier
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string Identifier { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinition.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinition.cs
@@ -36,7 +36,7 @@ namespace ReqIFSharp
     /// type. In <see cref="ReqIF"/>, each attribute value (<see cref="AttributeValue"/> element) is related to its data type (<see cref="DatatypeDefinition"/>  element) via
     /// an attribute definition (<see cref="AttributeDefinition"/> element).
     /// </remarks>
-    [Class(name: "ATTRIBUTE-DEFINITION", isAbstract: true)]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION", isAbstract: true)]
     public abstract class AttributeDefinition : AccessControlledElement
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinition.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinition.cs
@@ -36,6 +36,7 @@ namespace ReqIFSharp
     /// type. In <see cref="ReqIF"/>, each attribute value (<see cref="AttributeValue"/> element) is related to its data type (<see cref="DatatypeDefinition"/>  element) via
     /// an attribute definition (<see cref="AttributeDefinition"/> element).
     /// </remarks>
+    [Class(name: "ATTRIBUTE-DEFINITION", isAbstract: true)]
     public abstract class AttributeDefinition : AccessControlledElement
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionBoolean.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionBoolean.cs
@@ -85,13 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>        
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueBoolean DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionBoolean Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionBoolean.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionBoolean.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionBoolean"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool
     /// </remarks>
-    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-BOOLEAN")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-BOOLEAN", isAbstract: false)]
     public class AttributeDefinitionBoolean : AttributeDefinitionSimple
     {
         /// <summary>
@@ -85,13 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>        
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeValueBoolean DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DatatypeDefinitionBoolean Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionBoolean.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionBoolean.cs
@@ -39,6 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionBoolean"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool
     /// </remarks>
+    [Class(name: "ATTRIBUTE-DEFINITION-BOOLEAN")]
     public class AttributeDefinitionBoolean : AttributeDefinitionSimple
     {
         /// <summary>
@@ -84,11 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>        
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueBoolean DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionBoolean Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionBoolean.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionBoolean.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionBoolean"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool
     /// </remarks>
-    [Class(name: "ATTRIBUTE-DEFINITION-BOOLEAN")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-BOOLEAN")]
     public class AttributeDefinitionBoolean : AttributeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionDate.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionDate.cs
@@ -86,13 +86,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueDate DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionDate Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionDate.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionDate.cs
@@ -40,7 +40,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionDate"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool
     /// </remarks>    
-    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-DATE")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-DATE", isAbstract: false)]
     public class AttributeDefinitionDate : AttributeDefinitionSimple
     {
         /// <summary>
@@ -86,13 +86,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeValueDate DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DatatypeDefinitionDate Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionDate.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionDate.cs
@@ -40,6 +40,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionDate"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool
     /// </remarks>    
+    [Class(name: "ATTRIBUTE-DEFINITION-DATE")]
     public class AttributeDefinitionDate : AttributeDefinitionSimple
     {
         /// <summary>
@@ -85,11 +86,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueDate DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionDate Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionDate.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionDate.cs
@@ -40,7 +40,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionDate"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool
     /// </remarks>    
-    [Class(name: "ATTRIBUTE-DEFINITION-DATE")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-DATE")]
     public class AttributeDefinitionDate : AttributeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionEnumeration.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionEnumeration.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionEnumeration"/> element MAY contain a default value that represents the value that is used as an
     /// attribute value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
-    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-ENUMERATION")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-ENUMERATION", isAbstract: false)]
     public class AttributeDefinitionEnumeration : AttributeDefinition
     {
         /// <summary>
@@ -85,13 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeValueEnumeration DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DatatypeDefinitionEnumeration Type { get; set; }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace ReqIFSharp
         /// If set to false, this means that the user of a requirements authoring tool can pick exactly one of the values in the set of
         /// specified values as an enumeration attribute value.
         /// </value>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public bool IsMultiValued { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionEnumeration.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionEnumeration.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionEnumeration"/> element MAY contain a default value that represents the value that is used as an
     /// attribute value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
-    [Class(name: "ATTRIBUTE-DEFINITION-ENUMERATION")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-ENUMERATION")]
     public class AttributeDefinitionEnumeration : AttributeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionEnumeration.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionEnumeration.cs
@@ -85,13 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueEnumeration DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionEnumeration Type { get; set; }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace ReqIFSharp
         /// If set to false, this means that the user of a requirements authoring tool can pick exactly one of the values in the set of
         /// specified values as an enumeration attribute value.
         /// </value>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public bool IsMultiValued { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionEnumeration.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionEnumeration.cs
@@ -39,6 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionEnumeration"/> element MAY contain a default value that represents the value that is used as an
     /// attribute value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
+    [Class(name: "ATTRIBUTE-DEFINITION-ENUMERATION")]
     public class AttributeDefinitionEnumeration : AttributeDefinition
     {
         /// <summary>
@@ -84,11 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueEnumeration DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionEnumeration Type { get; set; }
 
         /// <summary>
@@ -134,6 +137,7 @@ namespace ReqIFSharp
         /// If set to false, this means that the user of a requirements authoring tool can pick exactly one of the values in the set of
         /// specified values as an enumeration attribute value.
         /// </value>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public bool IsMultiValued { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionInteger.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionInteger.cs
@@ -87,13 +87,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueInteger DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionInteger Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionInteger.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionInteger.cs
@@ -41,7 +41,7 @@ namespace ReqIFSharp
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// ReqIfSharp supports 64 bit singed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
-    [Class(name: "ATTRIBUTE-DEFINITION-INTEGER")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-INTEGER")]
     public class AttributeDefinitionInteger : AttributeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionInteger.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionInteger.cs
@@ -41,7 +41,7 @@ namespace ReqIFSharp
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// ReqIfSharp supports 64 bit singed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
-    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-INTEGER")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-INTEGER", isAbstract: false)]
     public class AttributeDefinitionInteger : AttributeDefinitionSimple
     {
         /// <summary>
@@ -87,13 +87,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeValueInteger DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DatatypeDefinitionInteger Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionInteger.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionInteger.cs
@@ -41,6 +41,7 @@ namespace ReqIFSharp
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// ReqIfSharp supports 64 bit singed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
+    [Class(name: "ATTRIBUTE-DEFINITION-INTEGER")]
     public class AttributeDefinitionInteger : AttributeDefinitionSimple
     {
         /// <summary>
@@ -86,11 +87,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueInteger DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionInteger Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionReal.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionReal.cs
@@ -40,7 +40,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionReal"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
-    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-REAL")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-REAL", isAbstract: false)]
     public class AttributeDefinitionReal : AttributeDefinitionSimple
     {
         /// <summary>
@@ -86,13 +86,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeValueReal DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DatatypeDefinitionReal Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionReal.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionReal.cs
@@ -86,13 +86,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueReal DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionReal Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionReal.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionReal.cs
@@ -40,6 +40,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionReal"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
+    [Class(name: "ATTRIBUTE-DEFINITION-REAL")]
     public class AttributeDefinitionReal : AttributeDefinitionSimple
     {
         /// <summary>
@@ -85,11 +86,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueReal DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionReal Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionReal.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionReal.cs
@@ -40,7 +40,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionReal"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
-    [Class(name: "ATTRIBUTE-DEFINITION-REAL")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-REAL")]
     public class AttributeDefinitionReal : AttributeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionSimple.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionSimple.cs
@@ -25,7 +25,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="AttributeDefinitionSimple"/> is the base class for simple type attributes.
     /// </summary>
-    [Class(name: "ATTRIBUTE-DEFINITION-SIMPLE", isAbstract: true)]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-SIMPLE", isAbstract: true)]
     public abstract class AttributeDefinitionSimple : AttributeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionSimple.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionSimple.cs
@@ -25,6 +25,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="AttributeDefinitionSimple"/> is the base class for simple type attributes.
     /// </summary>
+    [Class(name: "ATTRIBUTE-DEFINITION-SIMPLE", isAbstract: true)]
     public abstract class AttributeDefinitionSimple : AttributeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionString.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionString.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionString"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
-    [Class(name: "ATTRIBUTE-DEFINITION-STRING")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-STRING")]
     public class AttributeDefinitionString : AttributeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionString.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionString.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionString"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
-    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-STRING")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-STRING", isAbstract: false)]
     public class AttributeDefinitionString : AttributeDefinitionSimple
     {
         /// <summary>
@@ -85,13 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeValueString DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DatatypeDefinitionString Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionString.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionString.cs
@@ -39,6 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionString"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
+    [Class(name: "ATTRIBUTE-DEFINITION-STRING")]
     public class AttributeDefinitionString : AttributeDefinitionSimple
     {
         /// <summary>
@@ -84,11 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueString DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionString Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionString.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionString.cs
@@ -85,13 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueString DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionString Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionXHTML.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionXHTML.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionXHTML"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
-    [Class(name: "ATTRIBUTE-DEFINITION-XHTML")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-XHTML")]
     public class AttributeDefinitionXHTML : AttributeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionXHTML.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionXHTML.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionXHTML"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
-    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-XHTML")]
+    [ReqIfClass(name: "ATTRIBUTE-DEFINITION-XHTML", isAbstract: false)]
     public class AttributeDefinitionXHTML : AttributeDefinition
     {
         /// <summary>
@@ -85,13 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeValueXHTML DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DatatypeDefinitionXHTML Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionXHTML.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionXHTML.cs
@@ -39,6 +39,7 @@ namespace ReqIFSharp
     /// An <see cref="AttributeDefinitionXHTML"/> element MAY contain a default value that represents the value that is used as an attribute
     /// value if no attribute value is supplied by the user of the requirements authoring tool.
     /// </remarks>
+    [Class(name: "ATTRIBUTE-DEFINITION-XHTML")]
     public class AttributeDefinitionXHTML : AttributeDefinition
     {
         /// <summary>
@@ -84,11 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueXHTML DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionXHTML Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeDefinition/AttributeDefinitionXHTML.cs
+++ b/ReqIFSharp/AttributeDefinition/AttributeDefinitionXHTML.cs
@@ -85,13 +85,13 @@ namespace ReqIFSharp
         /// Gets or sets the owned default value that is used if no attribute value is supplied 
         /// by the user of the requirements authoring tool.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AttributeValueXHTML DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DatatypeDefinitionXHTML Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValue.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValue.cs
@@ -29,6 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="AttributeDefinition"/> is the base class for attribute values.
     /// </summary>
+    [Class(name: "ATTRIBUTE-VALUE", isAbstract: true)]
     public abstract class AttributeValue
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValue.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValue.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="AttributeDefinition"/> is the base class for attribute values.
     /// </summary>
-    [Class(name: "ATTRIBUTE-VALUE", isAbstract: true)]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE", isAbstract: true)]
     public abstract class AttributeValue
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueBoolean.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueBoolean.cs
@@ -96,7 +96,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public bool TheValue { get; set; }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a reference to the value definition
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionBoolean Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueBoolean.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueBoolean.cs
@@ -33,6 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueBoolean"/> class is to define a <see cref="bool"/> attribute value.
     /// </summary>
+    [Class(name: "ATTRIBUTE-VALUE-BOOLEAN")]
     public class AttributeValueBoolean : AttributeValueSimple
     {
         /// <summary>
@@ -95,6 +96,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public bool TheValue { get; set; }
 
         /// <summary>
@@ -120,6 +122,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a reference to the value definition
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionBoolean Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueBoolean.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueBoolean.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueBoolean"/> class is to define a <see cref="bool"/> attribute value.
     /// </summary>
-    [Class(name: "ATTRIBUTE-VALUE-BOOLEAN")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-BOOLEAN")]
     public class AttributeValueBoolean : AttributeValueSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueBoolean.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueBoolean.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueBoolean"/> class is to define a <see cref="bool"/> attribute value.
     /// </summary>
-    [ReqIfClass(name: "ATTRIBUTE-VALUE-BOOLEAN")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-BOOLEAN", isAbstract: false)]
     public class AttributeValueBoolean : AttributeValueSimple
     {
         /// <summary>
@@ -96,7 +96,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public bool TheValue { get; set; }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a reference to the value definition
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeDefinitionBoolean Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueDate.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueDate.cs
@@ -34,7 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueDate"/> class is to define a <see cref="DateTime"/> attribute value.
     /// </summary>
-    [Class(name: "ATTRIBUTE-VALUE-DATE")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-DATE")]
     public class AttributeValueDate : AttributeValueSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueDate.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueDate.cs
@@ -34,6 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueDate"/> class is to define a <see cref="DateTime"/> attribute value.
     /// </summary>
+    [Class(name: "ATTRIBUTE-VALUE-DATE")]
     public class AttributeValueDate : AttributeValueSimple
     {
         /// <summary>
@@ -85,6 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DateTime TheValue { get; set; }
 
         /// <summary>
@@ -110,6 +112,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the value definition.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionDate Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueDate.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueDate.cs
@@ -34,7 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueDate"/> class is to define a <see cref="DateTime"/> attribute value.
     /// </summary>
-    [ReqIfClass(name: "ATTRIBUTE-VALUE-DATE")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-DATE", isAbstract: false)]
     public class AttributeValueDate : AttributeValueSimple
     {
         /// <summary>
@@ -86,7 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DateTime TheValue { get; set; }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the value definition.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeDefinitionDate Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueDate.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueDate.cs
@@ -86,7 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DateTime TheValue { get; set; }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the value definition.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionDate Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueEnumeration.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueEnumeration.cs
@@ -102,7 +102,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets <see cref="EnumValue"/>s that are chosen from a set of specified values
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
         public List<EnumValue> Values => this.values;
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the attribute definition that relates the value to its data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionEnumeration Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueEnumeration.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueEnumeration.cs
@@ -34,7 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueEnumeration"/> class is to define an enumeration attribute value.
     /// </summary>
-    [ReqIfClass(name: "ATTRIBUTE-VALUE-ENUMERATION")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-ENUMERATION", isAbstract: false)]
     public class AttributeValueEnumeration : AttributeValue
     {
         /// <summary>
@@ -102,7 +102,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets <see cref="EnumValue"/>s that are chosen from a set of specified values
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<EnumValue> Values => this.values;
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the attribute definition that relates the value to its data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeDefinitionEnumeration Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueEnumeration.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueEnumeration.cs
@@ -34,6 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueEnumeration"/> class is to define an enumeration attribute value.
     /// </summary>
+    [Class(name: "ATTRIBUTE-VALUE-ENUMERATION")]
     public class AttributeValueEnumeration : AttributeValue
     {
         /// <summary>
@@ -101,6 +102,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets <see cref="EnumValue"/>s that are chosen from a set of specified values
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
         public List<EnumValue> Values => this.values;
 
         /// <summary>
@@ -127,6 +129,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the attribute definition that relates the value to its data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionEnumeration Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueEnumeration.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueEnumeration.cs
@@ -34,7 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueEnumeration"/> class is to define an enumeration attribute value.
     /// </summary>
-    [Class(name: "ATTRIBUTE-VALUE-ENUMERATION")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-ENUMERATION")]
     public class AttributeValueEnumeration : AttributeValue
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueInteger.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueInteger.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// ReqIfSharp supports 64 bit signed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
-    [Class(name: "ATTRIBUTE-VALUE-INTEGER")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-INTEGER")]
     public class AttributeValueInteger : AttributeValueSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueInteger.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueInteger.cs
@@ -100,7 +100,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long TheValue { get; set; }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the value definition.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionInteger Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueInteger.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueInteger.cs
@@ -37,6 +37,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// ReqIfSharp supports 64 bit signed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
+    [Class(name: "ATTRIBUTE-VALUE-INTEGER")]
     public class AttributeValueInteger : AttributeValueSimple
     {
         /// <summary>
@@ -99,6 +100,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long TheValue { get; set; }
 
         /// <summary>
@@ -124,6 +126,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the value definition.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionInteger Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueInteger.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueInteger.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// ReqIfSharp supports 64 bit signed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
-    [ReqIfClass(name: "ATTRIBUTE-VALUE-INTEGER")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-INTEGER", isAbstract: false)]
     public class AttributeValueInteger : AttributeValueSimple
     {
         /// <summary>
@@ -100,7 +100,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public long TheValue { get; set; }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the value definition.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeDefinitionInteger Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueReal.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueReal.cs
@@ -34,7 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueReal"/> class is to define a real attribute value.
     /// </summary>
-    [Class(name: "ATTRIBUTE-VALUE-REAL")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-REAL")]
     public class AttributeValueReal : AttributeValueSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueReal.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueReal.cs
@@ -97,7 +97,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public double TheValue { get; set; }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the reference to the value definition
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionReal Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueReal.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueReal.cs
@@ -34,6 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueReal"/> class is to define a real attribute value.
     /// </summary>
+    [Class(name: "ATTRIBUTE-VALUE-REAL")]
     public class AttributeValueReal : AttributeValueSimple
     {
         /// <summary>
@@ -96,6 +97,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public double TheValue { get; set; }
 
         /// <summary>
@@ -121,6 +123,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the reference to the value definition
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionReal Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueReal.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueReal.cs
@@ -34,7 +34,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueReal"/> class is to define a real attribute value.
     /// </summary>
-    [ReqIfClass(name: "ATTRIBUTE-VALUE-REAL")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-REAL", isAbstract: false)]
     public class AttributeValueReal : AttributeValueSimple
     {
         /// <summary>
@@ -97,7 +97,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public double TheValue { get; set; }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the reference to the value definition
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeDefinitionReal Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueSimple.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueSimple.cs
@@ -25,7 +25,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="AttributeValueSimple"/> is the base class for simple type attribute values.
     /// </summary>
-    [Class(name: "ATTRIBUTE-VALUE-SIMPLE", isAbstract: true)]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-SIMPLE", isAbstract: true)]
     public abstract class AttributeValueSimple : AttributeValue
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueSimple.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueSimple.cs
@@ -25,6 +25,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="AttributeValueSimple"/> is the base class for simple type attribute values.
     /// </summary>
+    [Class(name: "ATTRIBUTE-VALUE-SIMPLE", isAbstract: true)]
     public abstract class AttributeValueSimple : AttributeValue
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueString.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueString.cs
@@ -86,7 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string TheValue { get; set; }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets reference to the value definition
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionString Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueString.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueString.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueString"/> class is to define a <see cref="string"/> attribute value.
     /// </summary>
-    [ReqIfClass(name: "ATTRIBUTE-VALUE-STRING")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-STRING", isAbstract: false)]
     public class AttributeValueString : AttributeValueSimple
     {
         /// <summary>
@@ -86,7 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string TheValue { get; set; }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets reference to the value definition
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeDefinitionString Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueString.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueString.cs
@@ -33,6 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueString"/> class is to define a <see cref="string"/> attribute value.
     /// </summary>
+    [Class(name: "ATTRIBUTE-VALUE-STRING")]
     public class AttributeValueString : AttributeValueSimple
     {
         /// <summary>
@@ -85,6 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the attribute value
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string TheValue { get; set; }
 
         /// <summary>
@@ -102,6 +104,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets reference to the value definition
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionString Definition { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueString.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueString.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueString"/> class is to define a <see cref="string"/> attribute value.
     /// </summary>
-    [Class(name: "ATTRIBUTE-VALUE-STRING")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-STRING")]
     public class AttributeValueString : AttributeValueSimple
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueXHTML.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueXHTML.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueXHTML"/> class is to define an attribute value with XHTML contents.
     /// </summary>
-    [ReqIfClass(name: "ATTRIBUTE-VALUE-XHTML")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-XHTML", isAbstract: false)]
     public class AttributeValueXHTML : AttributeValue
     {
         /// <summary>
@@ -104,13 +104,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the XHTML Content
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string TheValue { get; set; }
 
         /// <summary>
         /// Gets or sets the Linkage to the original attribute value that has been saved if isSimplified is true.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string TheOriginalValue { get; set; }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the attribute definition that relates the value to its data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AttributeDefinitionXHTML Definition { get; set; }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value indicating whether the attribute value is a simplified representation of the original value.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public bool IsSimplified { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueXHTML.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueXHTML.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueXHTML"/> class is to define an attribute value with XHTML contents.
     /// </summary>
-    [Class(name: "ATTRIBUTE-VALUE-XHTML")]
+    [ReqIfClass(name: "ATTRIBUTE-VALUE-XHTML")]
     public class AttributeValueXHTML : AttributeValue
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueXHTML.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueXHTML.cs
@@ -37,6 +37,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="AttributeValueXHTML"/> class is to define an attribute value with XHTML contents.
     /// </summary>
+    [Class(name: "ATTRIBUTE-VALUE-XHTML")]
     public class AttributeValueXHTML : AttributeValue
     {
         /// <summary>
@@ -103,11 +104,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the XHTML Content
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string TheValue { get; set; }
 
         /// <summary>
         /// Gets or sets the Linkage to the original attribute value that has been saved if isSimplified is true.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string TheOriginalValue { get; set; }
 
         /// <summary>
@@ -138,6 +141,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the attribute definition that relates the value to its data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionXHTML Definition { get; set; }
 
         /// <summary>
@@ -180,6 +184,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value indicating whether the attribute value is a simplified representation of the original value.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public bool IsSimplified { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/AttributeValueXHTML.cs
+++ b/ReqIFSharp/AttributeValue/AttributeValueXHTML.cs
@@ -104,13 +104,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the XHTML Content
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string TheValue { get; set; }
 
         /// <summary>
         /// Gets or sets the Linkage to the original attribute value that has been saved if isSimplified is true.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string TheOriginalValue { get; set; }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Reference to the attribute definition that relates the value to its data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public AttributeDefinitionXHTML Definition { get; set; }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value indicating whether the attribute value is a simplified representation of the original value.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public bool IsSimplified { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/AttributeValue/ExternalObject.cs
+++ b/ReqIFSharp/AttributeValue/ExternalObject.cs
@@ -55,25 +55,25 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Uri of the <see cref="ExternalObject"/>, this may be a relative uri or an absolute uri
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string Uri { get; set; }
 
         /// <summary>
         /// Gets or sets the MimeType of the external object represented as a string
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string MimeType { get; set; }
 
         /// <summary>
         /// Gets or sets the height of the external object in case it is an image
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public int? Height { get; set; }
 
         /// <summary>
         /// Gets or sets the width of the external object in case it is an image
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public int? Width { get; set; }
         
         /// <summary>

--- a/ReqIFSharp/AttributeValue/ExternalObject.cs
+++ b/ReqIFSharp/AttributeValue/ExternalObject.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// The specification for the XTHML object element defines several XML attributes. For ReqIF, only a subset of these attributes is relevant and used.
     /// </remarks>
-    [ReqIfClass(name: "EXTERNAL-OBJECT")]
+    [ReqIfClass(name: "EXTERNAL-OBJECT", isAbstract: false)]
     public class ExternalObject
     {
         /// <summary>
@@ -55,25 +55,25 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Uri of the <see cref="ExternalObject"/>, this may be a relative uri or an absolute uri
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string Uri { get; set; }
 
         /// <summary>
         /// Gets or sets the MimeType of the external object represented as a string
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string MimeType { get; set; }
 
         /// <summary>
         /// Gets or sets the height of the external object in case it is an image
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public int? Height { get; set; }
 
         /// <summary>
         /// Gets or sets the width of the external object in case it is an image
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public int? Width { get; set; }
         
         /// <summary>

--- a/ReqIFSharp/AttributeValue/ExternalObject.cs
+++ b/ReqIFSharp/AttributeValue/ExternalObject.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// The specification for the XTHML object element defines several XML attributes. For ReqIF, only a subset of these attributes is relevant and used.
     /// </remarks>
-    [Class(name: "EXTERNAL-OBJECT")]
+    [ReqIfClass(name: "EXTERNAL-OBJECT")]
     public class ExternalObject
     {
         /// <summary>

--- a/ReqIFSharp/AttributeValue/ExternalObject.cs
+++ b/ReqIFSharp/AttributeValue/ExternalObject.cs
@@ -33,6 +33,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// The specification for the XTHML object element defines several XML attributes. For ReqIF, only a subset of these attributes is relevant and used.
     /// </remarks>
+    [Class(name: "EXTERNAL-OBJECT")]
     public class ExternalObject
     {
         /// <summary>
@@ -54,21 +55,25 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Uri of the <see cref="ExternalObject"/>, this may be a relative uri or an absolute uri
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string Uri { get; set; }
 
         /// <summary>
         /// Gets or sets the MimeType of the external object represented as a string
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string MimeType { get; set; }
 
         /// <summary>
         /// Gets or sets the height of the external object in case it is an image
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public int? Height { get; set; }
 
         /// <summary>
         /// Gets or sets the width of the external object in case it is an image
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public int? Width { get; set; }
         
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinition.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinition.cs
@@ -30,6 +30,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="DatatypeDefinition"/> is the base class for all data types available to the Exchange Document.
     /// </summary>
+    [Class(name: "DATATYPE-DEFINITION", isAbstract: true)]
     public abstract class DatatypeDefinition : Identifiable
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinition.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinition.cs
@@ -30,7 +30,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="DatatypeDefinition"/> is the base class for all data types available to the Exchange Document.
     /// </summary>
-    [Class(name: "DATATYPE-DEFINITION", isAbstract: true)]
+    [ReqIfClass(name: "DATATYPE-DEFINITION", isAbstract: true)]
     public abstract class DatatypeDefinition : Identifiable
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionBoolean.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionBoolean.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of Boolean data values in the Exchange Document.
     /// </remarks>
-    [Class(name: "DATATYPE-DEFINITION-BOOLEAN")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-BOOLEAN")]
     public class DatatypeDefinitionBoolean : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionBoolean.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionBoolean.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of Boolean data values in the Exchange Document.
     /// </remarks>
-    [ReqIfClass(name: "DATATYPE-DEFINITION-BOOLEAN")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-BOOLEAN", isAbstract: false)]
     public class DatatypeDefinitionBoolean : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionBoolean.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionBoolean.cs
@@ -32,6 +32,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of Boolean data values in the Exchange Document.
     /// </remarks>
+    [Class(name: "DATATYPE-DEFINITION-BOOLEAN")]
     public class DatatypeDefinitionBoolean : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionDate.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionDate.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of Date and Time data values in the Exchange Document.
     /// </remarks>
-    [ReqIfClass(name: "DATATYPE-DEFINITION-DATE")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-DATE", isAbstract: false)]
     public class DatatypeDefinitionDate : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionDate.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionDate.cs
@@ -33,6 +33,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of Date and Time data values in the Exchange Document.
     /// </remarks>
+    [Class(name: "DATATYPE-DEFINITION-DATE")]
     public class DatatypeDefinitionDate : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionDate.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionDate.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of Date and Time data values in the Exchange Document.
     /// </remarks>
-    [Class(name: "DATATYPE-DEFINITION-DATE")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-DATE")]
     public class DatatypeDefinitionDate : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionEnumeration.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionEnumeration.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// Data type definition for enumeration types. The set of enumeration values referenced by specifiedValues constrains the
     /// possible choices for enumeration attribute values
     /// </remarks>
-    [Class(name: "DATATYPE-DEFINITION-ENUMERATION")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-ENUMERATION")]
     public class DatatypeDefinitionEnumeration : DatatypeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionEnumeration.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionEnumeration.cs
@@ -88,7 +88,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the owned enumeration literals
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<EnumValue> SpecifiedValues => this.specifiedValues;
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionEnumeration.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionEnumeration.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// Data type definition for enumeration types. The set of enumeration values referenced by specifiedValues constrains the
     /// possible choices for enumeration attribute values
     /// </remarks>
-    [ReqIfClass(name: "DATATYPE-DEFINITION-ENUMERATION")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-ENUMERATION", isAbstract: false)]
     public class DatatypeDefinitionEnumeration : DatatypeDefinition
     {
         /// <summary>
@@ -88,7 +88,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the owned enumeration literals
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<EnumValue> SpecifiedValues => this.specifiedValues;
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionEnumeration.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionEnumeration.cs
@@ -37,6 +37,7 @@ namespace ReqIFSharp
     /// Data type definition for enumeration types. The set of enumeration values referenced by specifiedValues constrains the
     /// possible choices for enumeration attribute values
     /// </remarks>
+    [Class(name: "DATATYPE-DEFINITION-ENUMERATION")]
     public class DatatypeDefinitionEnumeration : DatatypeDefinition
     {
         /// <summary>
@@ -87,6 +88,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the owned enumeration literals
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<EnumValue> SpecifiedValues => this.specifiedValues;
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
@@ -83,13 +83,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value that denotes the largest negative data value representable by this data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long Min { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest positive data value representable by this data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long Max { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
@@ -37,6 +37,7 @@ namespace ReqIFSharp
     /// The representation of data values shall comply with the definitions in http://www.w3.org/TR/xmlschema-2/#integer
     /// ReqIfSharp supports 64-bit signed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
+    [Class(name: "DATATYPE-DEFINITION-INTEGER")]
     public class DatatypeDefinitionInteger : DatatypeDefinitionSimple
     {
         /// <summary>
@@ -82,11 +83,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value that denotes the largest negative data value representable by this data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long Min { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest positive data value representable by this data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long Max { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// The representation of data values shall comply with the definitions in http://www.w3.org/TR/xmlschema-2/#integer
     /// ReqIfSharp supports 64-bit signed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
-    [ReqIfClass(name: "DATATYPE-DEFINITION-INTEGER")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-INTEGER", isAbstract: false)]
     public class DatatypeDefinitionInteger : DatatypeDefinitionSimple
     {
         /// <summary>
@@ -83,13 +83,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value that denotes the largest negative data value representable by this data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public long Min { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest positive data value representable by this data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public long Max { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionInteger.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// The representation of data values shall comply with the definitions in http://www.w3.org/TR/xmlschema-2/#integer
     /// ReqIfSharp supports 64-bit signed integers (long) with the following range: -9223372036854775808 to 9223372036854775807
     /// </remarks>
-    [Class(name: "DATATYPE-DEFINITION-INTEGER")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-INTEGER")]
     public class DatatypeDefinitionInteger : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// This element defines a data type for the representation of Real data values in the Exchange Document.
     /// </summary>
-    [Class(name: "DATATYPE-DEFINITION-REAL")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-REAL")]
     public class DatatypeDefinitionReal : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// This element defines a data type for the representation of Real data values in the Exchange Document.
     /// </summary>
-    [ReqIfClass(name: "DATATYPE-DEFINITION-REAL")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-REAL", isAbstract: false)]
     public class DatatypeDefinitionReal : DatatypeDefinitionSimple
     {
         /// <summary>
@@ -78,19 +78,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value that Denotes the supported maximum precision of real numbers represented by this data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public long Accuracy { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest negative data value representable by this data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public double Min { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest positive data value representable by this data type.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public double Max { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
@@ -32,6 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// This element defines a data type for the representation of Real data values in the Exchange Document.
     /// </summary>
+    [Class(name: "DATATYPE-DEFINITION-REAL")]
     public class DatatypeDefinitionReal : DatatypeDefinitionSimple
     {
         /// <summary>
@@ -77,16 +78,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value that Denotes the supported maximum precision of real numbers represented by this data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long Accuracy { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest negative data value representable by this data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public double Min { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest positive data value representable by this data type.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public double Max { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionReal.cs
@@ -78,19 +78,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets a value that Denotes the supported maximum precision of real numbers represented by this data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long Accuracy { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest negative data value representable by this data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public double Min { get; set; }
 
         /// <summary>
         /// Gets or sets a value that denotes the largest positive data value representable by this data type.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public double Max { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionSimple.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionSimple.cs
@@ -25,7 +25,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="DatatypeDefinitionSimple"/> is the base class from which all primitive data types, except enumeration, are derived.
     /// </summary>
-    [Class(name: "DATATYPE-DEFINITION-SIMPLE", isAbstract: true)]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-SIMPLE", isAbstract: true)]
     public abstract class DatatypeDefinitionSimple : DatatypeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionSimple.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionSimple.cs
@@ -25,6 +25,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="DatatypeDefinitionSimple"/> is the base class from which all primitive data types, except enumeration, are derived.
     /// </summary>
+    [Class(name: "DATATYPE-DEFINITION-SIMPLE", isAbstract: true)]
     public abstract class DatatypeDefinitionSimple : DatatypeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
@@ -81,7 +81,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the maximum permissible string length
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long MaxLength { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
@@ -35,7 +35,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of String data values in the Exchange Document.
     /// </remarks>
-    [Class(name: "DATATYPE-DEFINITION-STRING")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-STRING")]
     public class DatatypeDefinitionString : DatatypeDefinitionSimple
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
@@ -35,7 +35,8 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of String data values in the Exchange Document.
     /// </remarks>
-    public class DatatypeDefinitionString : DatatypeDefinitionSimple 
+    [Class(name: "DATATYPE-DEFINITION-STRING")]
+    public class DatatypeDefinitionString : DatatypeDefinitionSimple
     {
         /// <summary>
         /// The <see cref="ILogger"/> used to log
@@ -80,6 +81,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the maximum permissible string length
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long MaxLength { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionString.cs
@@ -35,7 +35,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// This element defines a data type for the representation of String data values in the Exchange Document.
     /// </remarks>
-    [ReqIfClass(name: "DATATYPE-DEFINITION-STRING")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-STRING", isAbstract: false)]
     public class DatatypeDefinitionString : DatatypeDefinitionSimple
     {
         /// <summary>
@@ -81,7 +81,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the maximum permissible string length
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public long MaxLength { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionXHTML.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionXHTML.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="DatatypeDefinitionXHTML"/> class is to define XHTML formatted data.
     /// </summary>
-    [ReqIfClass(name: "DATATYPE-DEFINITION-XHTML")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-XHTML", isAbstract: false)]
     public class DatatypeDefinitionXHTML : DatatypeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionXHTML.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionXHTML.cs
@@ -29,6 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="DatatypeDefinitionXHTML"/> class is to define XHTML formatted data.
     /// </summary>
+    [Class(name: "DATATYPE-DEFINITION-XHTML")]
     public class DatatypeDefinitionXHTML : DatatypeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/DatatypeDefinitionXHTML.cs
+++ b/ReqIFSharp/Datatype/DatatypeDefinitionXHTML.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The purpose of the <see cref="DatatypeDefinitionXHTML"/> class is to define XHTML formatted data.
     /// </summary>
-    [Class(name: "DATATYPE-DEFINITION-XHTML")]
+    [ReqIfClass(name: "DATATYPE-DEFINITION-XHTML")]
     public class DatatypeDefinitionXHTML : DatatypeDefinition
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/EmbeddedValue.cs
+++ b/ReqIFSharp/Datatype/EmbeddedValue.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="EmbeddedValue"/> class represents additional information related to enumeration literals.
     /// </summary>
-    [Class(name: "EMBEDDED-VALUE")]
+    [ReqIfClass(name: "EMBEDDED-VALUE")]
     public class EmbeddedValue
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/EmbeddedValue.cs
+++ b/ReqIFSharp/Datatype/EmbeddedValue.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="EmbeddedValue"/> class represents additional information related to enumeration literals.
     /// </summary>
-    [ReqIfClass(name: "EMBEDDED-VALUE")]
+    [ReqIfClass(name: "EMBEDDED-VALUE", isAbstract: false)]
     public class EmbeddedValue
     {
         /// <summary>
@@ -68,7 +68,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the numerical value corresponding to the enumeration literal.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public long Key { get; set; }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace ReqIFSharp
         /// <example>
         /// example: a color
         /// </example>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string OtherContent { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/EmbeddedValue.cs
+++ b/ReqIFSharp/Datatype/EmbeddedValue.cs
@@ -32,6 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="EmbeddedValue"/> class represents additional information related to enumeration literals.
     /// </summary>
+    [Class(name: "EMBEDDED-VALUE")]
     public class EmbeddedValue
     {
         /// <summary>
@@ -67,6 +68,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the numerical value corresponding to the enumeration literal.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long Key { get; set; }
 
         /// <summary>
@@ -75,6 +77,7 @@ namespace ReqIFSharp
         /// <example>
         /// example: a color
         /// </example>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string OtherContent { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/EmbeddedValue.cs
+++ b/ReqIFSharp/Datatype/EmbeddedValue.cs
@@ -68,7 +68,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the numerical value corresponding to the enumeration literal.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public long Key { get; set; }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace ReqIFSharp
         /// <example>
         /// example: a color
         /// </example>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string OtherContent { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/EnumValue.cs
+++ b/ReqIFSharp/Datatype/EnumValue.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The class <see cref="EnumValue"/> represents enumeration literals.
     /// </summary>
-    [Class(name: "ENUM-VALUE")]
+    [ReqIfClass(name: "ENUM-VALUE")]
     public class EnumValue : Identifiable
     {
         /// <summary>

--- a/ReqIFSharp/Datatype/EnumValue.cs
+++ b/ReqIFSharp/Datatype/EnumValue.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The class <see cref="EnumValue"/> represents enumeration literals.
     /// </summary>
-    [ReqIfClass(name: "ENUM-VALUE")]
+    [ReqIfClass(name: "ENUM-VALUE", isAbstract: false)]
     public class EnumValue : Identifiable
     {
         /// <summary>
@@ -69,7 +69,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the owned <see cref="EmbeddedValue"/>
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public EmbeddedValue Properties { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/EnumValue.cs
+++ b/ReqIFSharp/Datatype/EnumValue.cs
@@ -29,6 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The class <see cref="EnumValue"/> represents enumeration literals.
     /// </summary>
+    [Class(name: "ENUM-VALUE")]
     public class EnumValue : Identifiable
     {
         /// <summary>
@@ -68,6 +69,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the owned <see cref="EmbeddedValue"/>
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
         public EmbeddedValue Properties { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Datatype/EnumValue.cs
+++ b/ReqIFSharp/Datatype/EnumValue.cs
@@ -69,7 +69,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the owned <see cref="EmbeddedValue"/>
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
         public EmbeddedValue Properties { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Decorators/AggregationKind.cs
+++ b/ReqIFSharp/Decorators/AggregationKind.cs
@@ -1,0 +1,45 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="AggregationKind.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace ReqIFSharp
+{
+    /// <summary>
+    /// Specifies the kind of aggregation that applies to a property, mirroring the UML
+    /// <c>AggregationKind</c> enumeration. It documents whether a property merely references
+    /// another model element or owns it (containment).
+    /// </summary>
+    public enum AggregationKind
+    {
+        /// <summary>
+        /// The property is a plain reference (or a scalar value); the referenced element is not owned.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The property is a shared aggregation; the referenced element may be shared by multiple owners.
+        /// </summary>
+        Shared,
+
+        /// <summary>
+        /// The property is a composite aggregation; the owning element contains and owns the value(s).
+        /// </summary>
+        Composite
+    }
+}

--- a/ReqIFSharp/Decorators/ClassAttribute.cs
+++ b/ReqIFSharp/Decorators/ClassAttribute.cs
@@ -1,0 +1,58 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="ClassAttribute.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace ReqIFSharp
+{
+    using System;
+
+    /// <summary>
+    /// Attribute used to decorate the model classes with metadata sourced from the ReqIF metamodel,
+    /// so that the relationships and characteristics of each class are self-documenting.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class ClassAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClassAttribute"/> class.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the ReqIF metaclass that the decorated class represents (e.g. <c>SPEC-OBJECT</c>).
+        /// </param>
+        /// <param name="isAbstract">
+        /// A value indicating whether the decorated class is abstract. An abstract class does not provide
+        /// a complete declaration and cannot be instantiated on its own.
+        /// </param>
+        public ClassAttribute(string name = "", bool isAbstract = false)
+        {
+            this.Name = name;
+            this.IsAbstract = isAbstract;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the ReqIF metaclass that the decorated class represents.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the decorated class is abstract.
+        /// </summary>
+        public bool IsAbstract { get; set; }
+    }
+}

--- a/ReqIFSharp/Decorators/PropertyAttribute.cs
+++ b/ReqIFSharp/Decorators/PropertyAttribute.cs
@@ -1,0 +1,126 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="PropertyAttribute.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace ReqIFSharp
+{
+    using System;
+
+    /// <summary>
+    /// Attribute used to decorate the model properties with metadata sourced from the ReqIF metamodel,
+    /// so that the multiplicity, ownership and characteristics of each property are self-documenting.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class PropertyAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyAttribute"/> class.
+        /// </summary>
+        /// <param name="aggregation">
+        /// The <see cref="AggregationKind"/> that specifies whether the property references or owns its value(s).
+        /// </param>
+        /// <param name="lowerValue">
+        /// The lower bound (minimum multiplicity) of the property.
+        /// </param>
+        /// <param name="upperValue">
+        /// The upper bound (maximum multiplicity) of the property. Use <see cref="int.MaxValue"/> for unbounded.
+        /// </param>
+        /// <param name="isOrdered">
+        /// A value indicating whether the values of a multivalued property are ordered.
+        /// </param>
+        /// <param name="isReadOnly">
+        /// A value indicating whether the property is read-only.
+        /// </param>
+        /// <param name="isDerived">
+        /// A value indicating whether the property is derived (its value is computed from other values).
+        /// </param>
+        /// <param name="isDerivedUnion">
+        /// A value indicating whether the property is a derived union.
+        /// </param>
+        /// <param name="isUnique">
+        /// A value indicating whether the values of a multivalued property are unique.
+        /// </param>
+        /// <param name="defaultValue">
+        /// The default value of the property, if any.
+        /// </param>
+        public PropertyAttribute(AggregationKind aggregation = AggregationKind.None, int lowerValue = 1, int upperValue = 1,
+            bool isOrdered = false,
+            bool isReadOnly = false,
+            bool isDerived = false,
+            bool isDerivedUnion = false,
+            bool isUnique = true,
+            string defaultValue = null)
+        {
+            this.Aggregation = aggregation;
+            this.LowerValue = lowerValue;
+            this.UpperValue = upperValue;
+            this.IsOrdered = isOrdered;
+            this.IsReadOnly = isReadOnly;
+            this.IsDerived = isDerived;
+            this.IsDerivedUnion = isDerivedUnion;
+            this.IsUnique = isUnique;
+            this.DefaultValue = defaultValue;
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="AggregationKind"/>.
+        /// </summary>
+        public AggregationKind Aggregation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lower bound (minimum multiplicity) of the property.
+        /// </summary>
+        public int LowerValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the upper bound (maximum multiplicity) of the property.
+        /// </summary>
+        public int UpperValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the values of a multivalued property are ordered.
+        /// </summary>
+        public bool IsOrdered { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the property is read-only.
+        /// </summary>
+        public bool IsReadOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the property is derived.
+        /// </summary>
+        public bool IsDerived { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the property is a derived union.
+        /// </summary>
+        public bool IsDerivedUnion { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the values of a multivalued property are unique.
+        /// </summary>
+        public bool IsUnique { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default value of the property, if any.
+        /// </summary>
+        public string DefaultValue { get; set; }
+    }
+}

--- a/ReqIFSharp/Decorators/ReqIfClassAttribute.cs
+++ b/ReqIFSharp/Decorators/ReqIfClassAttribute.cs
@@ -1,5 +1,5 @@
 // -------------------------------------------------------------------------------------------------
-// <copyright file="ClassAttribute.cs" company="Starion Group S.A.">
+// <copyright file="ReqIfClassAttribute.cs" company="Starion Group S.A.">
 //
 //   Copyright 2017-2026 Starion Group S.A.
 //
@@ -27,10 +27,10 @@ namespace ReqIFSharp
     /// so that the relationships and characteristics of each class are self-documenting.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public sealed class ClassAttribute : Attribute
+    public sealed class ReqIfClassAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ClassAttribute"/> class.
+        /// Initializes a new instance of the <see cref="ReqIfClassAttribute"/> class.
         /// </summary>
         /// <param name="name">
         /// The name of the ReqIF metaclass that the decorated class represents (e.g. <c>SPEC-OBJECT</c>).
@@ -39,7 +39,7 @@ namespace ReqIFSharp
         /// A value indicating whether the decorated class is abstract. An abstract class does not provide
         /// a complete declaration and cannot be instantiated on its own.
         /// </param>
-        public ClassAttribute(string name = "", bool isAbstract = false)
+        public ReqIfClassAttribute(string name = "", bool isAbstract = false)
         {
             this.Name = name;
             this.IsAbstract = isAbstract;

--- a/ReqIFSharp/Decorators/ReqIfPropertyAttribute.cs
+++ b/ReqIFSharp/Decorators/ReqIfPropertyAttribute.cs
@@ -1,5 +1,5 @@
 // -------------------------------------------------------------------------------------------------
-// <copyright file="PropertyAttribute.cs" company="Starion Group S.A.">
+// <copyright file="ReqIfPropertyAttribute.cs" company="Starion Group S.A.">
 //
 //   Copyright 2017-2026 Starion Group S.A.
 //
@@ -27,10 +27,10 @@ namespace ReqIFSharp
     /// so that the multiplicity, ownership and characteristics of each property are self-documenting.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    public sealed class PropertyAttribute : Attribute
+    public sealed class ReqIfPropertyAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PropertyAttribute"/> class.
+        /// Initializes a new instance of the <see cref="ReqIfPropertyAttribute"/> class.
         /// </summary>
         /// <param name="aggregation">
         /// The <see cref="AggregationKind"/> that specifies whether the property references or owns its value(s).
@@ -59,7 +59,7 @@ namespace ReqIFSharp
         /// <param name="defaultValue">
         /// The default value of the property, if any.
         /// </param>
-        public PropertyAttribute(AggregationKind aggregation = AggregationKind.None, int lowerValue = 1, int upperValue = 1,
+        public ReqIfPropertyAttribute(AggregationKind aggregation = AggregationKind.None, int lowerValue = 1, int upperValue = 1,
             bool isOrdered = false,
             bool isReadOnly = false,
             bool isDerived = false,

--- a/ReqIFSharp/Identifiable.cs
+++ b/ReqIFSharp/Identifiable.cs
@@ -32,6 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="Identifiable"/> Abstract base class provides an identification concept for <see cref="ReqIF"/> elements.
     /// </summary>
+    [Class(name: "IDENTIFIABLE", isAbstract: true)]
     public abstract class Identifiable
     {
         /// <summary>
@@ -77,6 +78,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the optional additional description for the information element.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string Description { get; set; }
 
         /// <summary>
@@ -85,6 +87,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The value of the identifier must be a well-formed <code>xsd:ID</code>.
         /// </remarks>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string Identifier { get; set; }
 
         /// <summary>
@@ -95,16 +98,19 @@ namespace ReqIFSharp
         /// <example>
         /// date time formatting: 2005-03-04T10:24:18+01:00 (MET time zone).
         /// </example>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DateTime LastChange { get; set; }
 
         /// <summary>
         /// Gets or sets the human-readable name for the information element.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string LongName { get; set; }
 
         /// <summary>
         /// Gets or sets optional alternative identification element.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AlternativeId AlternativeId { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Identifiable.cs
+++ b/ReqIFSharp/Identifiable.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="Identifiable"/> Abstract base class provides an identification concept for <see cref="ReqIF"/> elements.
     /// </summary>
-    [Class(name: "IDENTIFIABLE", isAbstract: true)]
+    [ReqIfClass(name: "IDENTIFIABLE", isAbstract: true)]
     public abstract class Identifiable
     {
         /// <summary>

--- a/ReqIFSharp/Identifiable.cs
+++ b/ReqIFSharp/Identifiable.cs
@@ -78,7 +78,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the optional additional description for the information element.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string Description { get; set; }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The value of the identifier must be a well-formed <code>xsd:ID</code>.
         /// </remarks>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string Identifier { get; set; }
 
         /// <summary>
@@ -98,19 +98,19 @@ namespace ReqIFSharp
         /// <example>
         /// date time formatting: 2005-03-04T10:24:18+01:00 (MET time zone).
         /// </example>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DateTime LastChange { get; set; }
 
         /// <summary>
         /// Gets or sets the human-readable name for the information element.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string LongName { get; set; }
 
         /// <summary>
         /// Gets or sets optional alternative identification element.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
         public AlternativeId AlternativeId { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/Identifiable.cs
+++ b/ReqIFSharp/Identifiable.cs
@@ -78,7 +78,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the optional additional description for the information element.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string Description { get; set; }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The value of the identifier must be a well-formed <code>xsd:ID</code>.
         /// </remarks>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string Identifier { get; set; }
 
         /// <summary>
@@ -98,19 +98,19 @@ namespace ReqIFSharp
         /// <example>
         /// date time formatting: 2005-03-04T10:24:18+01:00 (MET time zone).
         /// </example>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DateTime LastChange { get; set; }
 
         /// <summary>
         /// Gets or sets the human-readable name for the information element.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string LongName { get; set; }
 
         /// <summary>
         /// Gets or sets optional alternative identification element.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public AlternativeId AlternativeId { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIF.cs
+++ b/ReqIFSharp/ReqIF.cs
@@ -31,6 +31,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIF"/> class constitutes the root element of a ReqIF Exchange Document.
     /// </summary>
+    [Class(name: "REQ-IF")]
     public class ReqIF
     {
         /// <summary>
@@ -73,16 +74,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the mandatory Exchange Document header, which contains metadata relevant for this exchange.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
         public ReqIFHeader TheHeader { get; set; }
 
         /// <summary>
         /// Gets the mandatory Exchange Document content.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
         public ReqIFContent CoreContent { get; set; }
 
         /// <summary>
         /// Gets the optional Exchange Document content based on tool extensions, if such extensions and content are present.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<ReqIFToolExtension> ToolExtension { get; set; } = new List<ReqIFToolExtension>();
 
         /// <summary>
@@ -91,6 +95,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The format is defined by the standard for specifying languages in XML documents proposed by the <a href="http://www.w3.org/TR/xml11/#sec-lang-tag"> W3C </a>
         /// </remarks>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string Lang { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIF.cs
+++ b/ReqIFSharp/ReqIF.cs
@@ -31,7 +31,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIF"/> class constitutes the root element of a ReqIF Exchange Document.
     /// </summary>
-    [Class(name: "REQ-IF")]
+    [ReqIfClass(name: "REQ-IF")]
     public class ReqIF
     {
         /// <summary>

--- a/ReqIFSharp/ReqIF.cs
+++ b/ReqIFSharp/ReqIF.cs
@@ -74,19 +74,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the mandatory Exchange Document header, which contains metadata relevant for this exchange.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
         public ReqIFHeader TheHeader { get; set; }
 
         /// <summary>
         /// Gets the mandatory Exchange Document content.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
         public ReqIFContent CoreContent { get; set; }
 
         /// <summary>
         /// Gets the optional Exchange Document content based on tool extensions, if such extensions and content are present.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<ReqIFToolExtension> ToolExtension { get; set; } = new List<ReqIFToolExtension>();
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The format is defined by the standard for specifying languages in XML documents proposed by the <a href="http://www.w3.org/TR/xml11/#sec-lang-tag"> W3C </a>
         /// </remarks>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string Lang { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIF.cs
+++ b/ReqIFSharp/ReqIF.cs
@@ -31,7 +31,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIF"/> class constitutes the root element of a ReqIF Exchange Document.
     /// </summary>
-    [ReqIfClass(name: "REQ-IF")]
+    [ReqIfClass(name: "REQ-IF", isAbstract: false)]
     public class ReqIF
     {
         /// <summary>
@@ -74,19 +74,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the mandatory Exchange Document header, which contains metadata relevant for this exchange.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public ReqIFHeader TheHeader { get; set; }
 
         /// <summary>
         /// Gets the mandatory Exchange Document content.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public ReqIFContent CoreContent { get; set; }
 
         /// <summary>
         /// Gets the optional Exchange Document content based on tool extensions, if such extensions and content are present.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<ReqIFToolExtension> ToolExtension { get; set; } = new List<ReqIFToolExtension>();
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The format is defined by the standard for specifying languages in XML documents proposed by the <a href="http://www.w3.org/TR/xml11/#sec-lang-tag"> W3C </a>
         /// </remarks>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string Lang { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIFContent.cs
+++ b/ReqIFSharp/ReqIFContent.cs
@@ -99,37 +99,37 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the <see cref="DatatypeDefinition"/>s
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<DatatypeDefinition> DataTypes => this.dataTypes;
 
         /// <summary>
         /// Gets the <see cref="SpecType"/>s
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecType> SpecTypes => this.specTypes;
 
         /// <summary>
         /// Gets the <see cref="SpecObject"/>
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecObject> SpecObjects => this.specObjects;
 
         /// <summary>
         /// Gets the <see cref="SpecRelation"/>
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecRelation> SpecRelations => this.specRelations;
 
         /// <summary>
         /// Gets the <see cref="Specification"/>
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<Specification> Specifications => this.specifications;
 
         /// <summary>
         /// Gets the <see cref="RelationGroup"/>
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<RelationGroup> SpecRelationGroups => this.specRelationGroups;
 
         /// <summary>

--- a/ReqIFSharp/ReqIFContent.cs
+++ b/ReqIFSharp/ReqIFContent.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIFContent"/> class represents the mandatory content of a ReqIF Exchange Document.
     /// </summary>
-    [Class(name: "REQ-IF-CONTENT")]
+    [ReqIfClass(name: "REQ-IF-CONTENT")]
     public class ReqIFContent
     {
         /// <summary>

--- a/ReqIFSharp/ReqIFContent.cs
+++ b/ReqIFSharp/ReqIFContent.cs
@@ -32,7 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIFContent"/> class represents the mandatory content of a ReqIF Exchange Document.
     /// </summary>
-    [ReqIfClass(name: "REQ-IF-CONTENT")]
+    [ReqIfClass(name: "REQ-IF-CONTENT", isAbstract: false)]
     public class ReqIFContent
     {
         /// <summary>
@@ -99,37 +99,37 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the <see cref="DatatypeDefinition"/>s
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<DatatypeDefinition> DataTypes => this.dataTypes;
 
         /// <summary>
         /// Gets the <see cref="SpecType"/>s
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<SpecType> SpecTypes => this.specTypes;
 
         /// <summary>
         /// Gets the <see cref="SpecObject"/>
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<SpecObject> SpecObjects => this.specObjects;
 
         /// <summary>
         /// Gets the <see cref="SpecRelation"/>
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<SpecRelation> SpecRelations => this.specRelations;
 
         /// <summary>
         /// Gets the <see cref="Specification"/>
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<Specification> Specifications => this.specifications;
 
         /// <summary>
         /// Gets the <see cref="RelationGroup"/>
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<RelationGroup> SpecRelationGroups => this.specRelationGroups;
 
         /// <summary>

--- a/ReqIFSharp/ReqIFContent.cs
+++ b/ReqIFSharp/ReqIFContent.cs
@@ -32,6 +32,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIFContent"/> class represents the mandatory content of a ReqIF Exchange Document.
     /// </summary>
+    [Class(name: "REQ-IF-CONTENT")]
     public class ReqIFContent
     {
         /// <summary>
@@ -98,31 +99,37 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the <see cref="DatatypeDefinition"/>s
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<DatatypeDefinition> DataTypes => this.dataTypes;
 
         /// <summary>
         /// Gets the <see cref="SpecType"/>s
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecType> SpecTypes => this.specTypes;
 
         /// <summary>
         /// Gets the <see cref="SpecObject"/>
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecObject> SpecObjects => this.specObjects;
 
         /// <summary>
         /// Gets the <see cref="SpecRelation"/>
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecRelation> SpecRelations => this.specRelations;
 
         /// <summary>
         /// Gets the <see cref="Specification"/>
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<Specification> Specifications => this.specifications;
 
         /// <summary>
         /// Gets the <see cref="RelationGroup"/>
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<RelationGroup> SpecRelationGroups => this.specRelationGroups;
 
         /// <summary>

--- a/ReqIFSharp/ReqIFHeader.cs
+++ b/ReqIFSharp/ReqIFHeader.cs
@@ -34,6 +34,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// Meta-information held in the <see cref="ReqIFHeader"/> element is applicable to the Exchange Document as a whole.
     /// </remarks>
+    [Class(name: "REQ-IF-HEADER")]
     public class ReqIFHeader
     {
         /// <summary>
@@ -63,6 +64,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets an optional comment associated with the Exchange Document as a whole
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string Comment { get; set; }
 
         /// <summary>
@@ -74,6 +76,7 @@ namespace ReqIFSharp
         /// <example>
         /// Example: 2005-03-04T10:24:18+01:00 (MET time zone).
         /// </example>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DateTime CreationTime { get; set; }
 
         /// <summary>
@@ -82,26 +85,31 @@ namespace ReqIFSharp
         /// <remarks>
         /// Examples for repositoryID: databaseId, URL.
         /// </remarks>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string RepositoryId { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the exporting "ReqIF" tool.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string ReqIFToolId { get; set; }
 
         /// <summary>
         /// Gets or sets the ReqIF interchange format and protocol version
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string ReqIFVersion { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the exporting requirements management tool
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string SourceToolId { get; set; }
 
         /// <summary>
         /// Gets or sets the title of the Exchange Document.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string Title { get; set; }
 
         /// <summary>
@@ -110,6 +118,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The value of the identifier is of the XML Schema data type “xsd::ID”
         /// </remarks>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string Identifier { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIFHeader.cs
+++ b/ReqIFSharp/ReqIFHeader.cs
@@ -64,7 +64,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets an optional comment associated with the Exchange Document as a whole
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string Comment { get; set; }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace ReqIFSharp
         /// <example>
         /// Example: 2005-03-04T10:24:18+01:00 (MET time zone).
         /// </example>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public DateTime CreationTime { get; set; }
 
         /// <summary>
@@ -85,31 +85,31 @@ namespace ReqIFSharp
         /// <remarks>
         /// Examples for repositoryID: databaseId, URL.
         /// </remarks>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string RepositoryId { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the exporting "ReqIF" tool.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string ReqIFToolId { get; set; }
 
         /// <summary>
         /// Gets or sets the ReqIF interchange format and protocol version
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string ReqIFVersion { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the exporting requirements management tool
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string SourceToolId { get; set; }
 
         /// <summary>
         /// Gets or sets the title of the Exchange Document.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string Title { get; set; }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The value of the identifier is of the XML Schema data type “xsd::ID”
         /// </remarks>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public string Identifier { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIFHeader.cs
+++ b/ReqIFSharp/ReqIFHeader.cs
@@ -34,7 +34,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// Meta-information held in the <see cref="ReqIFHeader"/> element is applicable to the Exchange Document as a whole.
     /// </remarks>
-    [ReqIfClass(name: "REQ-IF-HEADER")]
+    [ReqIfClass(name: "REQ-IF-HEADER", isAbstract: false)]
     public class ReqIFHeader
     {
         /// <summary>
@@ -64,7 +64,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets an optional comment associated with the Exchange Document as a whole
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string Comment { get; set; }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace ReqIFSharp
         /// <example>
         /// Example: 2005-03-04T10:24:18+01:00 (MET time zone).
         /// </example>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public DateTime CreationTime { get; set; }
 
         /// <summary>
@@ -85,31 +85,31 @@ namespace ReqIFSharp
         /// <remarks>
         /// Examples for repositoryID: databaseId, URL.
         /// </remarks>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string RepositoryId { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the exporting "ReqIF" tool.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string ReqIFToolId { get; set; }
 
         /// <summary>
         /// Gets or sets the ReqIF interchange format and protocol version
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string ReqIFVersion { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the exporting requirements management tool
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string SourceToolId { get; set; }
 
         /// <summary>
         /// Gets or sets the title of the Exchange Document.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string Title { get; set; }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace ReqIFSharp
         /// <remarks>
         /// The value of the identifier is of the XML Schema data type “xsd::ID”
         /// </remarks>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string Identifier { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIFHeader.cs
+++ b/ReqIFSharp/ReqIFHeader.cs
@@ -34,7 +34,7 @@ namespace ReqIFSharp
     /// <remarks>
     /// Meta-information held in the <see cref="ReqIFHeader"/> element is applicable to the Exchange Document as a whole.
     /// </remarks>
-    [Class(name: "REQ-IF-HEADER")]
+    [ReqIfClass(name: "REQ-IF-HEADER")]
     public class ReqIFHeader
     {
         /// <summary>

--- a/ReqIFSharp/ReqIFToolExtension.cs
+++ b/ReqIFSharp/ReqIFToolExtension.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIFToolExtension"/> class allows the optional inclusion of tool-specific information into a ReqIF Exchange Document.
     /// </summary>
-    [Class(name: "REQ-IF-TOOL-EXTENSION")]
+    [ReqIfClass(name: "REQ-IF-TOOL-EXTENSION")]
     public class ReqIFToolExtension
     {
         /// <summary>

--- a/ReqIFSharp/ReqIFToolExtension.cs
+++ b/ReqIFSharp/ReqIFToolExtension.cs
@@ -52,7 +52,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the InnerXml of the <see cref="ReqIFToolExtension"/>
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string InnerXml { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIFToolExtension.cs
+++ b/ReqIFSharp/ReqIFToolExtension.cs
@@ -29,6 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIFToolExtension"/> class allows the optional inclusion of tool-specific information into a ReqIF Exchange Document.
     /// </summary>
+    [Class(name: "REQ-IF-TOOL-EXTENSION")]
     public class ReqIFToolExtension
     {
         /// <summary>
@@ -51,6 +52,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the InnerXml of the <see cref="ReqIFToolExtension"/>
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public string InnerXml { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/ReqIFToolExtension.cs
+++ b/ReqIFSharp/ReqIFToolExtension.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// <summary>
     /// The <see cref="ReqIFToolExtension"/> class allows the optional inclusion of tool-specific information into a ReqIF Exchange Document.
     /// </summary>
-    [ReqIfClass(name: "REQ-IF-TOOL-EXTENSION")]
+    [ReqIfClass(name: "REQ-IF-TOOL-EXTENSION", isAbstract: false)]
     public class ReqIFToolExtension
     {
         /// <summary>
@@ -52,7 +52,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the InnerXml of the <see cref="ReqIFToolExtension"/>
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public string InnerXml { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/RelationGroup.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/RelationGroup.cs
@@ -40,7 +40,7 @@ namespace ReqIFSharp
     /// <example>
     /// a <see cref="RelationGroup"/> instance may represent a set of relations between a customer requirements <see cref="Specification"/> and a system requirements <see cref="Specification"/>.
     /// </example>
-    [Class(name: "RELATION-GROUP")]
+    [ReqIfClass(name: "RELATION-GROUP")]
     public class RelationGroup : SpecElementWithAttributes
     {
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/RelationGroup.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/RelationGroup.cs
@@ -40,7 +40,7 @@ namespace ReqIFSharp
     /// <example>
     /// a <see cref="RelationGroup"/> instance may represent a set of relations between a customer requirements <see cref="Specification"/> and a system requirements <see cref="Specification"/>.
     /// </example>
-    [ReqIfClass(name: "RELATION-GROUP")]
+    [ReqIfClass(name: "RELATION-GROUP", isAbstract: false)]
     public class RelationGroup : SpecElementWithAttributes
     {
         /// <summary>
@@ -94,25 +94,25 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the <see cref="RelationGroupType"/> reference
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public RelationGroupType Type { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Specification"/> that contains <see cref="SpecObject"/> instances that are source objects of the relations.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public Specification SourceSpecification { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Specification"/> that contains <see cref="SpecObject"/> instances that are target objects of the relations.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public Specification TargetSpecification { get; set; }
 
         /// <summary>
         /// Gets the grouped <see cref="SpecRelation"/>s
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<SpecRelation> SpecRelations => this.specRelations;
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/RelationGroup.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/RelationGroup.cs
@@ -40,6 +40,7 @@ namespace ReqIFSharp
     /// <example>
     /// a <see cref="RelationGroup"/> instance may represent a set of relations between a customer requirements <see cref="Specification"/> and a system requirements <see cref="Specification"/>.
     /// </example>
+    [Class(name: "RELATION-GROUP")]
     public class RelationGroup : SpecElementWithAttributes
     {
         /// <summary>
@@ -93,21 +94,25 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the <see cref="RelationGroupType"/> reference
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public RelationGroupType Type { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Specification"/> that contains <see cref="SpecObject"/> instances that are source objects of the relations.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public Specification SourceSpecification { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Specification"/> that contains <see cref="SpecObject"/> instances that are target objects of the relations.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public Specification TargetSpecification { get; set; }
 
         /// <summary>
         /// Gets the grouped <see cref="SpecRelation"/>s
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecRelation> SpecRelations => this.specRelations;
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/RelationGroup.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/RelationGroup.cs
@@ -94,25 +94,25 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the <see cref="RelationGroupType"/> reference
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public RelationGroupType Type { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Specification"/> that contains <see cref="SpecObject"/> instances that are source objects of the relations.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public Specification SourceSpecification { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Specification"/> that contains <see cref="SpecObject"/> instances that are target objects of the relations.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public Specification TargetSpecification { get; set; }
 
         /// <summary>
         /// Gets the grouped <see cref="SpecRelation"/>s
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecRelation> SpecRelations => this.specRelations;
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecElementWithAttributes.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecElementWithAttributes.cs
@@ -37,7 +37,7 @@ namespace ReqIFSharp
     /// While this class aggregates the values of the attributes, the association to the attributes’ types that define the acceptable
     /// values for the attributes is realized by concrete sub classes of this class.
     /// </remarks>
-    [Class(name: "SPEC-ELEMENT-WITH-ATTRIBUTES", isAbstract: true)]
+    [ReqIfClass(name: "SPEC-ELEMENT-WITH-ATTRIBUTES", isAbstract: true)]
     public abstract class SpecElementWithAttributes : Identifiable
     {
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecElementWithAttributes.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecElementWithAttributes.cs
@@ -37,6 +37,7 @@ namespace ReqIFSharp
     /// While this class aggregates the values of the attributes, the association to the attributes’ types that define the acceptable
     /// values for the attributes is realized by concrete sub classes of this class.
     /// </remarks>
+    [Class(name: "SPEC-ELEMENT-WITH-ATTRIBUTES", isAbstract: true)]
     public abstract class SpecElementWithAttributes : Identifiable
     {
         /// <summary>
@@ -89,6 +90,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the values of the attributes owned by the element.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<AttributeValue> Values => this.values;
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecElementWithAttributes.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecElementWithAttributes.cs
@@ -90,7 +90,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the values of the attributes owned by the element.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<AttributeValue> Values => this.values;
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecElementWithAttributes.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecElementWithAttributes.cs
@@ -90,7 +90,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the values of the attributes owned by the element.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<AttributeValue> Values => this.values;
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecHierarchy.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecHierarchy.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// The tree is created by references of <see cref="SpecHierarchy"/> instances to other <see cref="SpecHierarchy"/> instances.
     /// Each node has additionally a reference to a <see cref="SpecObject"/> resulting in a hierarchical structure of <see cref="SpecObject"/>s
     /// </remarks>
-    [Class(name: "SPEC-HIERARCHY")]
+    [ReqIfClass(name: "SPEC-HIERARCHY")]
     public class SpecHierarchy : AccessControlledElement
     {
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecHierarchy.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecHierarchy.cs
@@ -39,6 +39,7 @@ namespace ReqIFSharp
     /// The tree is created by references of <see cref="SpecHierarchy"/> instances to other <see cref="SpecHierarchy"/> instances.
     /// Each node has additionally a reference to a <see cref="SpecObject"/> resulting in a hierarchical structure of <see cref="SpecObject"/>s
     /// </remarks>
+    [Class(name: "SPEC-HIERARCHY")]
     public class SpecHierarchy : AccessControlledElement
     {
         /// <summary>
@@ -129,16 +130,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the Down links to next level of owned SpecHierarchy.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecHierarchy> Children => this.children;
 
         /// <summary>
         /// Gets the attributes whose values are editable for the <see cref="SpecHierarchy"/> by a tool user
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
         public List<AttributeDefinition> EditableAtts => this.editableAtts;
 
         /// <summary>
         /// Gets or sets the reference to the associated <see cref="SpecObject"/>
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecObject Object { get; set; }
 
         /// <summary>
@@ -151,6 +155,7 @@ namespace ReqIFSharp
         /// The root node of the table hierarchy is related to the SpecObject element that is the root of the table by the object
         /// association.
         /// </remarks>
+        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public bool IsTableInternal { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecHierarchy.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecHierarchy.cs
@@ -39,7 +39,7 @@ namespace ReqIFSharp
     /// The tree is created by references of <see cref="SpecHierarchy"/> instances to other <see cref="SpecHierarchy"/> instances.
     /// Each node has additionally a reference to a <see cref="SpecObject"/> resulting in a hierarchical structure of <see cref="SpecObject"/>s
     /// </remarks>
-    [ReqIfClass(name: "SPEC-HIERARCHY")]
+    [ReqIfClass(name: "SPEC-HIERARCHY", isAbstract: false)]
     public class SpecHierarchy : AccessControlledElement
     {
         /// <summary>
@@ -130,19 +130,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the Down links to next level of owned SpecHierarchy.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<SpecHierarchy> Children => this.children;
 
         /// <summary>
         /// Gets the attributes whose values are editable for the <see cref="SpecHierarchy"/> by a tool user
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<AttributeDefinition> EditableAtts => this.editableAtts;
 
         /// <summary>
         /// Gets or sets the reference to the associated <see cref="SpecObject"/>
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public SpecObject Object { get; set; }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace ReqIFSharp
         /// The root node of the table hierarchy is related to the SpecObject element that is the root of the table by the object
         /// association.
         /// </remarks>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public bool IsTableInternal { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecHierarchy.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecHierarchy.cs
@@ -130,19 +130,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the Down links to next level of owned SpecHierarchy.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecHierarchy> Children => this.children;
 
         /// <summary>
         /// Gets the attributes whose values are editable for the <see cref="SpecHierarchy"/> by a tool user
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue)]
         public List<AttributeDefinition> EditableAtts => this.editableAtts;
 
         /// <summary>
         /// Gets or sets the reference to the associated <see cref="SpecObject"/>
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecObject Object { get; set; }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace ReqIFSharp
         /// The root node of the table hierarchy is related to the SpecObject element that is the root of the table by the object
         /// association.
         /// </remarks>
-        [Property(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1)]
         public bool IsTableInternal { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecObject.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecObject.cs
@@ -86,7 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the <see cref="SpecObject"/> reference.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecObjectType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecObject.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecObject.cs
@@ -38,7 +38,7 @@ namespace ReqIFSharp
     /// The <see cref="SpecObject"/> instance itself does not carry the requirements text or any other user defined content.
     /// This data is stored in <see cref="AttributeValue"/> instances that are associated to the <see cref="SpecObject"/> instance.
     /// </remarks>
-    [Class(name: "SPEC-OBJECT")]
+    [ReqIfClass(name: "SPEC-OBJECT")]
     public class SpecObject : SpecElementWithAttributes
     {
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecObject.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecObject.cs
@@ -38,6 +38,7 @@ namespace ReqIFSharp
     /// The <see cref="SpecObject"/> instance itself does not carry the requirements text or any other user defined content.
     /// This data is stored in <see cref="AttributeValue"/> instances that are associated to the <see cref="SpecObject"/> instance.
     /// </remarks>
+    [Class(name: "SPEC-OBJECT")]
     public class SpecObject : SpecElementWithAttributes
     {
         /// <summary>
@@ -85,6 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the <see cref="SpecObject"/> reference.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecObjectType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecObject.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecObject.cs
@@ -38,7 +38,7 @@ namespace ReqIFSharp
     /// The <see cref="SpecObject"/> instance itself does not carry the requirements text or any other user defined content.
     /// This data is stored in <see cref="AttributeValue"/> instances that are associated to the <see cref="SpecObject"/> instance.
     /// </remarks>
-    [ReqIfClass(name: "SPEC-OBJECT")]
+    [ReqIfClass(name: "SPEC-OBJECT", isAbstract: false)]
     public class SpecObject : SpecElementWithAttributes
     {
         /// <summary>
@@ -86,7 +86,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the <see cref="SpecObject"/> reference.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public SpecObjectType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecRelation.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecRelation.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// Defines relations (links) between two <see cref="SpecObject"/> instances.
     /// </summary>
-    [ReqIfClass(name: "SPEC-RELATION")]
+    [ReqIfClass(name: "SPEC-RELATION", isAbstract: false)]
     public class SpecRelation : SpecElementWithAttributes
     {
         /// <summary>
@@ -81,19 +81,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Source object of the relationship.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public SpecObject Source { get; set; }
 
         /// <summary>
         /// Gets or sets the Target object of the relationship.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public SpecObject Target { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="SpecRelationType"/> of the relationship
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public SpecRelationType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecRelation.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecRelation.cs
@@ -33,6 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// Defines relations (links) between two <see cref="SpecObject"/> instances.
     /// </summary>
+    [Class(name: "SPEC-RELATION")]
     public class SpecRelation : SpecElementWithAttributes
     {
         /// <summary>
@@ -80,16 +81,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Source object of the relationship.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecObject Source { get; set; }
 
         /// <summary>
         /// Gets or sets the Target object of the relationship.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecObject Target { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="SpecRelationType"/> of the relationship
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecRelationType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecRelation.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecRelation.cs
@@ -81,19 +81,19 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets or sets the Source object of the relationship.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecObject Source { get; set; }
 
         /// <summary>
         /// Gets or sets the Target object of the relationship.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecObject Target { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="SpecRelationType"/> of the relationship
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecRelationType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/SpecRelation.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/SpecRelation.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// <summary>
     /// Defines relations (links) between two <see cref="SpecObject"/> instances.
     /// </summary>
-    [Class(name: "SPEC-RELATION")]
+    [ReqIfClass(name: "SPEC-RELATION")]
     public class SpecRelation : SpecElementWithAttributes
     {
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/Specification.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/Specification.cs
@@ -35,7 +35,7 @@ namespace ReqIFSharp
     /// Represents a hierarchically structured requirements specification.
     /// It is the root node of the tree that hierarchically structures <see cref="SpecObject"/> instances.
     /// </summary>
-    [ReqIfClass(name: "SPECIFICATION")]
+    [ReqIfClass(name: "SPECIFICATION", isAbstract: false)]
     public class Specification : SpecElementWithAttributes
     {
         /// <summary>
@@ -79,13 +79,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the links to next level of owned SpecHierarchy.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<SpecHierarchy> Children => this.children;
 
         /// <summary>
         /// Gets or sets the <see cref="SpecificationType"/> reference.
         /// </summary>
-        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public SpecificationType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/Specification.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/Specification.cs
@@ -79,13 +79,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the links to next level of owned SpecHierarchy.
         /// </summary>
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecHierarchy> Children => this.children;
 
         /// <summary>
         /// Gets or sets the <see cref="SpecificationType"/> reference.
         /// </summary>
-        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
+        [ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecificationType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/Specification.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/Specification.cs
@@ -35,6 +35,7 @@ namespace ReqIFSharp
     /// Represents a hierarchically structured requirements specification.
     /// It is the root node of the tree that hierarchically structures <see cref="SpecObject"/> instances.
     /// </summary>
+    [Class(name: "SPECIFICATION")]
     public class Specification : SpecElementWithAttributes
     {
         /// <summary>
@@ -78,11 +79,13 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the links to next level of owned SpecHierarchy.
         /// </summary>
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<SpecHierarchy> Children => this.children;
 
         /// <summary>
         /// Gets or sets the <see cref="SpecificationType"/> reference.
         /// </summary>
+        [Property(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1)]
         public SpecificationType Type { get; set; }
 
         /// <summary>

--- a/ReqIFSharp/SpecElementWithAttributes/Specification.cs
+++ b/ReqIFSharp/SpecElementWithAttributes/Specification.cs
@@ -35,7 +35,7 @@ namespace ReqIFSharp
     /// Represents a hierarchically structured requirements specification.
     /// It is the root node of the tree that hierarchically structures <see cref="SpecObject"/> instances.
     /// </summary>
-    [Class(name: "SPECIFICATION")]
+    [ReqIfClass(name: "SPECIFICATION")]
     public class Specification : SpecElementWithAttributes
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/RelationGroupType.cs
+++ b/ReqIFSharp/SpecType/RelationGroupType.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from <see cref="SpecType"/>. By using <see cref="RelationGroupType"/> elements, <see cref="RelationGroup"/> elements can
     /// be associated with attribute names, default values, data types, etc.
     /// </remarks>
-    [Class(name: "RELATION-GROUP-TYPE")]
+    [ReqIfClass(name: "RELATION-GROUP-TYPE")]
     public class RelationGroupType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/RelationGroupType.cs
+++ b/ReqIFSharp/SpecType/RelationGroupType.cs
@@ -29,6 +29,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from <see cref="SpecType"/>. By using <see cref="RelationGroupType"/> elements, <see cref="RelationGroup"/> elements can
     /// be associated with attribute names, default values, data types, etc.
     /// </remarks>
+    [Class(name: "RELATION-GROUP-TYPE")]
     public class RelationGroupType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/RelationGroupType.cs
+++ b/ReqIFSharp/SpecType/RelationGroupType.cs
@@ -29,7 +29,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from <see cref="SpecType"/>. By using <see cref="RelationGroupType"/> elements, <see cref="RelationGroup"/> elements can
     /// be associated with attribute names, default values, data types, etc.
     /// </remarks>
-    [ReqIfClass(name: "RELATION-GROUP-TYPE")]
+    [ReqIfClass(name: "RELATION-GROUP-TYPE", isAbstract: false)]
     public class RelationGroupType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecObjectType.cs
+++ b/ReqIFSharp/SpecType/SpecObjectType.cs
@@ -27,6 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecObjectType elements, multiple requirements can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
+    [Class(name: "SPEC-OBJECT-TYPE")]
     public class SpecObjectType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecObjectType.cs
+++ b/ReqIFSharp/SpecType/SpecObjectType.cs
@@ -27,7 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecObjectType elements, multiple requirements can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
-    [ReqIfClass(name: "SPEC-OBJECT-TYPE")]
+    [ReqIfClass(name: "SPEC-OBJECT-TYPE", isAbstract: false)]
     public class SpecObjectType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecObjectType.cs
+++ b/ReqIFSharp/SpecType/SpecObjectType.cs
@@ -27,7 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecObjectType elements, multiple requirements can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
-    [Class(name: "SPEC-OBJECT-TYPE")]
+    [ReqIfClass(name: "SPEC-OBJECT-TYPE")]
     public class SpecObjectType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecRelationType.cs
+++ b/ReqIFSharp/SpecType/SpecRelationType.cs
@@ -27,6 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecObjectType elements, multiple requirements can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
+    [Class(name: "SPEC-RELATION-TYPE")]
     public class SpecRelationType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecRelationType.cs
+++ b/ReqIFSharp/SpecType/SpecRelationType.cs
@@ -27,7 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecObjectType elements, multiple requirements can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
-    [ReqIfClass(name: "SPEC-RELATION-TYPE")]
+    [ReqIfClass(name: "SPEC-RELATION-TYPE", isAbstract: false)]
     public class SpecRelationType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecRelationType.cs
+++ b/ReqIFSharp/SpecType/SpecRelationType.cs
@@ -27,7 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecObjectType elements, multiple requirements can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
-    [Class(name: "SPEC-RELATION-TYPE")]
+    [ReqIfClass(name: "SPEC-RELATION-TYPE")]
     public class SpecRelationType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecType.cs
+++ b/ReqIFSharp/SpecType/SpecType.cs
@@ -92,7 +92,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the set of attribute definitions.
         /// </summary>        
-        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         public List<AttributeDefinition> SpecAttributes => this.specAttributes;
 
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecType.cs
+++ b/ReqIFSharp/SpecType/SpecType.cs
@@ -33,6 +33,7 @@ namespace ReqIFSharp
     /// Contains a set of attribute definitions. By using an instance of a subclass of <see cref="SpecType"/>, multiple elements can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
+    [Class(name: "SPEC-TYPE", isAbstract: true)]
     public abstract class SpecType : Identifiable
     {
         /// <summary>
@@ -91,6 +92,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the set of attribute definitions.
         /// </summary>        
+        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<AttributeDefinition> SpecAttributes => this.specAttributes;
 
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecType.cs
+++ b/ReqIFSharp/SpecType/SpecType.cs
@@ -33,7 +33,7 @@ namespace ReqIFSharp
     /// Contains a set of attribute definitions. By using an instance of a subclass of <see cref="SpecType"/>, multiple elements can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
-    [Class(name: "SPEC-TYPE", isAbstract: true)]
+    [ReqIfClass(name: "SPEC-TYPE", isAbstract: true)]
     public abstract class SpecType : Identifiable
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecType.cs
+++ b/ReqIFSharp/SpecType/SpecType.cs
@@ -92,7 +92,7 @@ namespace ReqIFSharp
         /// <summary>
         /// Gets the set of attribute definitions.
         /// </summary>        
-        [Property(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
+        [ReqIfProperty(aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue)]
         public List<AttributeDefinition> SpecAttributes => this.specAttributes;
 
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecificationType.cs
+++ b/ReqIFSharp/SpecType/SpecificationType.cs
@@ -27,7 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecificationType elements, multiple specifications can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
-    [ReqIfClass(name: "SPECIFICATION-TYPE")]
+    [ReqIfClass(name: "SPECIFICATION-TYPE", isAbstract: false)]
     public class SpecificationType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecificationType.cs
+++ b/ReqIFSharp/SpecType/SpecificationType.cs
@@ -27,6 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecificationType elements, multiple specifications can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
+    [Class(name: "SPECIFICATION-TYPE")]
     public class SpecificationType : SpecType
     {
         /// <summary>

--- a/ReqIFSharp/SpecType/SpecificationType.cs
+++ b/ReqIFSharp/SpecType/SpecificationType.cs
@@ -27,7 +27,7 @@ namespace ReqIFSharp
     /// Inherits a set of attribute definitions from SpecType. By using SpecificationType elements, multiple specifications can be
     /// associated with the same set of attribute definitions (attribute names, default values, data types, etc.).
     /// </summary>
-    [Class(name: "SPECIFICATION-TYPE")]
+    [ReqIfClass(name: "SPECIFICATION-TYPE")]
     public class SpecificationType : SpecType
     {
         /// <summary>


### PR DESCRIPTION
## Summary

Implements #27 — add UML-like metadata to the model classes and properties (as done in the COMET-SDK / uml4net) so that ReqIF metamodel relationships are self-documenting.

Two decorators are introduced under `ReqIFSharp/Decorators`, modelled on [uml4net's `Decorators`](https://github.com/STARIONGROUP/uml4net/tree/development/uml4net/Decorators) but reduced to what ReqIF actually models and prefixed with `ReqIf` to avoid collisions (e.g. with `NUnit.Framework.PropertyAttribute`):

- **`ReqIfClassAttribute`** (used as `[ReqIfClass(...)]`) — `name` (the ReqIF metaclass / XML element name) and `isAbstract`.
- **`ReqIfPropertyAttribute`** (used as `[ReqIfProperty(...)]`) — `aggregation` (containment vs reference), `lowerValue`/`upperValue` multiplicity, `isOrdered`, `isReadOnly`, `isDerived`, `isDerivedUnion`, `isUnique`, `defaultValue`.
- **`AggregationKind`** enum (`None` / `Shared` / `Composite`).

`[ReqIfClass]` is applied to all 54 model classes and `[ReqIfProperty]` to every metamodel property, with multiplicity and aggregation values sourced from the embedded `reqif.xsd`. The decorators live in the `ReqIFSharp` namespace, so no extra `using` is needed on the model classes.

Per the issue scope, uml4net's `Implements` / `Subsetted` / `RedefinedBy` / `RedefinedProperty` decorators were **not** ported — ReqIFSharp has no interfaces or UML generalization-sets to attach them to. An `xmiId` field was also omitted (ReqIFSharp does not round-trip XMI).

## Explicit arguments at every use-site

Every decorator usage passes **all** constructor arguments explicitly — including the optional ones that would otherwise fall back to defaults — so the metadata is fully self-documenting where it is applied:

```csharp
[ReqIfClass(name: "SPEC-OBJECT", isAbstract: false)]
public class SpecObject : SpecElementWithAttributes

[ReqIfProperty(aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
public SpecObjectType Type { get; set; }
```

Concrete classes carry `isAbstract: false` and abstract bases `isAbstract: true`; all 87 `[ReqIfProperty]` usages list the full nine-argument set.

## Completeness guard

`ModelMetadataTestFixture` is a reflection-driven test that fails if **any** model class or metamodel property is left undecorated, or if multiplicity is inconsistent (`Upper >= Lower`, `Upper >= 1`). Container back-references (e.g. `DocumentRoot`, `ReqIFContent`, `Owner`) and polymorphic convenience accessors (`ObjectValue`, the base `Type`/`Definition` aliases) are in a documented exclusion list. This keeps future model additions honest.

(Note: explicitness itself cannot be asserted by reflection — explicitly-passed default arguments and omitted ones compile to identical attribute metadata — so it is maintained as a source convention.)

## Verification

- `dotnet build ReqIFSharp.sln -c Release` — 0 warnings / 0 errors on `netstandard2.0`.
- `dotnet test ReqIFSharp.sln` — **376 tests pass** (292 core incl. 10 new decorator tests, 84 extensions).
- The decorators are inert metadata; (de)serialization behaviour is unchanged.

## Notes

- 48 model files annotated; 3 new decorator source files (`ReqIfClassAttribute`, `ReqIfPropertyAttribute`, `AggregationKind`); 3 new test fixtures.
- No `.csproj`/version changes.
- The `ReqIf` prefix on both decorators avoids the `NUnit.Framework.PropertyAttribute` collision entirely, so no test-side `using` alias is required.