### PR TITLE
[Fix] retain namespaces and root attributes on round-trip; fixes #44

### DIFF
--- a/ReqIFSharp.Tests/NamespaceRetentionTestFixture.cs
+++ b/ReqIFSharp.Tests/NamespaceRetentionTestFixture.cs
@@ -20,8 +20,10 @@
 
 namespace ReqIFSharp.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.IO.Compression;
     using System.Linq;
     using System.Text;
     using System.Threading;
@@ -149,13 +151,162 @@ namespace ReqIFSharp.Tests
             Assert.That(attributes["xmlns:xhtml"], Is.EqualTo("http://www.w3.org/1999/xhtml"));
         }
 
+        [TestCase("Datatype-Demo.reqif")]
+        [TestCase("ProR_Traceability-Template-v1.0.reqif")]
+        [TestCase("DefaultValueDemo.reqif")]
+        [TestCase("reqifsharpgenerated.reqif")]
+        public void Verify_that_root_attributes_of_reqif_files_survive_roundtrip(string fileName)
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", fileName);
+
+            IDictionary<string, string> source;
+            using (var sourceStream = File.OpenRead(path))
+            {
+                source = ExtractRootAttributes(sourceStream);
+            }
+
+            var deserializer = new ReqIFDeserializer();
+            var serializer = new ReqIFSerializer();
+
+            var reqif = deserializer.Deserialize(path).First();
+
+            using var output = new MemoryStream();
+            serializer.Serialize(new[] { reqif }, output, SupportedFileExtensionKind.Reqif);
+
+            var serialized = ExtractRootAttributes(output);
+
+            AssertAttributesRetained(source, serialized, fileName);
+        }
+
+        [TestCase("Spielwiese.reqifz", 1)]
+        [TestCase("requirements-and-objects.reqifz", 1)]
+        [TestCase("test-multiple-reqif.reqifz", 2)]
+        public void Verify_that_namespace_declarations_of_reqifz_archives_survive_roundtrip(string fileName, int expectedDocumentCount)
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", fileName);
+
+            IDictionary<string, string> sourceNamespaces;
+            using (var sourceStream = File.OpenRead(path))
+            {
+                sourceNamespaces = UnionNamespaceDeclarations(ExtractArchiveRootAttributes(sourceStream));
+            }
+
+            var deserializer = new ReqIFDeserializer();
+            var serializer = new ReqIFSerializer();
+
+            var reqifs = deserializer.Deserialize(path).ToList();
+            Assert.That(reqifs, Has.Count.EqualTo(expectedDocumentCount));
+
+            using var output = new MemoryStream();
+            serializer.Serialize(reqifs, output, SupportedFileExtensionKind.Reqifz);
+
+            var outputDocuments = ExtractArchiveRootAttributes(output);
+            Assert.That(outputDocuments, Has.Count.EqualTo(expectedDocumentCount), $"{fileName}: the number of serialized documents changed");
+
+            var outputNamespaces = UnionNamespaceDeclarations(outputDocuments);
+
+            AssertAttributesRetained(sourceNamespaces, outputNamespaces, fileName);
+        }
+
+        [TestCase("Spielwiese.reqifz", 1)]
+        [TestCase("test-multiple-reqif.reqifz", 2)]
+        public async System.Threading.Tasks.Task Verify_that_namespace_declarations_of_reqifz_archives_survive_roundtrip_async(string fileName, int expectedDocumentCount)
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", fileName);
+
+            IDictionary<string, string> sourceNamespaces;
+            using (var sourceStream = File.OpenRead(path))
+            {
+                sourceNamespaces = UnionNamespaceDeclarations(ExtractArchiveRootAttributes(sourceStream));
+            }
+
+            var deserializer = new ReqIFDeserializer();
+            var serializer = new ReqIFSerializer();
+
+            var reqifs = (await deserializer.DeserializeAsync(path, CancellationToken.None)).ToList();
+            Assert.That(reqifs, Has.Count.EqualTo(expectedDocumentCount));
+
+            using var output = new MemoryStream();
+            await serializer.SerializeAsync(reqifs, output, SupportedFileExtensionKind.Reqifz, CancellationToken.None);
+
+            var outputNamespaces = UnionNamespaceDeclarations(ExtractArchiveRootAttributes(output));
+
+            AssertAttributesRetained(sourceNamespaces, outputNamespaces, fileName);
+        }
+
+        /// <summary>
+        /// Asserts that every attribute in <paramref name="source"/> is present in <paramref name="serialized"/>
+        /// with the same value (the serializer may add declarations such as the XHTML namespace, but must not drop any).
+        /// </summary>
+        private static void AssertAttributesRetained(IDictionary<string, string> source, IDictionary<string, string> serialized, string context)
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var attribute in source)
+                {
+                    Assert.That(serialized.ContainsKey(attribute.Key), Is.True, $"{context}: the '{attribute.Key}' attribute was not retained");
+                    Assert.That(serialized.TryGetValue(attribute.Key, out var value) ? value : null, Is.EqualTo(attribute.Value), $"{context}: the value of '{attribute.Key}' changed");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Reads the <c>REQ-IF</c> root attributes of every <c>.reqif</c> entry contained in a <c>.reqifz</c> archive.
+        /// </summary>
+        private static IList<IDictionary<string, string>> ExtractArchiveRootAttributes(Stream reqifzStream)
+        {
+            if (reqifzStream.CanSeek)
+            {
+                reqifzStream.Position = 0;
+            }
+
+            var documents = new List<IDictionary<string, string>>();
+
+            using var archive = new ZipArchive(reqifzStream, ZipArchiveMode.Read, leaveOpen: true);
+
+            foreach (var entry in archive.Entries)
+            {
+                if (entry.FullName.EndsWith(".reqif", StringComparison.OrdinalIgnoreCase))
+                {
+                    using var entryStream = entry.Open();
+                    documents.Add(ExtractRootAttributes(entryStream));
+                }
+            }
+
+            return documents;
+        }
+
+        /// <summary>
+        /// Collects the union of namespace declarations (<c>xmlns</c> / <c>xmlns:prefix</c>) across the supplied documents.
+        /// </summary>
+        private static IDictionary<string, string> UnionNamespaceDeclarations(IEnumerable<IDictionary<string, string>> documents)
+        {
+            var union = new Dictionary<string, string>();
+
+            foreach (var document in documents)
+            {
+                foreach (var attribute in document)
+                {
+                    if (attribute.Key == "xmlns" || attribute.Key.StartsWith("xmlns:", StringComparison.Ordinal))
+                    {
+                        union[attribute.Key] = attribute.Value;
+                    }
+                }
+            }
+
+            return union;
+        }
+
         /// <summary>
         /// Reads the attributes declared on the <c>REQ-IF</c> root element of a serialized document, keyed by
         /// their qualified name (e.g. <c>xmlns</c>, <c>xmlns:configuration</c>, <c>xsi:schemaLocation</c>).
         /// </summary>
         private static IDictionary<string, string> ExtractRootAttributes(Stream stream)
         {
-            stream.Position = 0;
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
 
             var attributes = new Dictionary<string, string>();
 

--- a/ReqIFSharp.Tests/NamespaceRetentionTestFixture.cs
+++ b/ReqIFSharp.Tests/NamespaceRetentionTestFixture.cs
@@ -1,0 +1,184 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="NamespaceRetentionTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2017-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace ReqIFSharp.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Xml;
+
+    using NUnit.Framework;
+
+    using ReqIFSharp;
+
+    /// <summary>
+    /// Suite of tests that verify the namespace declarations and root attributes of a <see cref="ReqIF"/>
+    /// document are retained when it is deserialized and serialized to a new destination (issue #44).
+    /// </summary>
+    [TestFixture]
+    public class NamespaceRetentionTestFixture
+    {
+        private const string ReqIFNamespace = "http://www.omg.org/spec/ReqIF/20110401/reqif.xsd";
+        private const string XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
+
+        private string datatypeDemoPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.datatypeDemoPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "Datatype-Demo.reqif");
+        }
+
+        [Test]
+        public void Verify_that_namespace_declarations_are_retained_on_roundtrip()
+        {
+            var deserializer = new ReqIFDeserializer();
+            var serializer = new ReqIFSerializer();
+
+            var reqif = deserializer.Deserialize(this.datatypeDemoPath).First();
+
+            using var output = new MemoryStream();
+            serializer.Serialize(new[] { reqif }, output, SupportedFileExtensionKind.Reqif);
+
+            var attributes = ExtractRootAttributes(output);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(attributes.ContainsKey("xmlns"), Is.True, "the default ReqIF namespace declaration is missing");
+                Assert.That(attributes["xmlns"], Is.EqualTo(ReqIFNamespace));
+                Assert.That(attributes["xmlns:configuration"], Is.EqualTo("http://eclipse.org/rmf/pror/toolextensions/1.0"));
+                Assert.That(attributes["xmlns:id"], Is.EqualTo("http://pror.org/presentation/id"));
+                Assert.That(attributes["xmlns:xhtml"], Is.EqualTo("http://www.w3.org/1999/xhtml"));
+            });
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task Verify_that_namespace_declarations_are_retained_on_roundtrip_async()
+        {
+            var deserializer = new ReqIFDeserializer();
+            var serializer = new ReqIFSerializer();
+
+            var reqif = (await deserializer.DeserializeAsync(this.datatypeDemoPath, CancellationToken.None)).First();
+
+            using var output = new MemoryStream();
+            await serializer.SerializeAsync(new[] { reqif }, output, SupportedFileExtensionKind.Reqif, CancellationToken.None);
+
+            var attributes = ExtractRootAttributes(output);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(attributes["xmlns"], Is.EqualTo(ReqIFNamespace));
+                Assert.That(attributes["xmlns:configuration"], Is.EqualTo("http://eclipse.org/rmf/pror/toolextensions/1.0"));
+                Assert.That(attributes["xmlns:id"], Is.EqualTo("http://pror.org/presentation/id"));
+                Assert.That(attributes["xmlns:xhtml"], Is.EqualTo("http://www.w3.org/1999/xhtml"));
+            });
+        }
+
+        [Test]
+        public void Verify_that_prefixed_root_attribute_is_retained_on_roundtrip()
+        {
+            const string schemaLocation = "http://www.omg.org/spec/ReqIF/20110401/reqif.xsd reqif.xsd";
+
+            // start from a known-valid document and add an xsi namespace declaration plus an
+            // xsi:schemaLocation prefixed attribute to the REQ-IF root element
+            var xml = File.ReadAllText(this.datatypeDemoPath)
+                .Replace(
+                    $"xmlns=\"{ReqIFNamespace}\"",
+                    $"xmlns=\"{ReqIFNamespace}\" xmlns:xsi=\"{XsiNamespace}\" xsi:schemaLocation=\"{schemaLocation}\"");
+
+            var deserializer = new ReqIFDeserializer();
+            var serializer = new ReqIFSerializer();
+
+            ReqIF reqif;
+            using (var input = new MemoryStream(Encoding.UTF8.GetBytes(xml)))
+            {
+                reqif = deserializer.Deserialize(input, SupportedFileExtensionKind.Reqif).First();
+            }
+
+            using var output = new MemoryStream();
+            serializer.Serialize(new[] { reqif }, output, SupportedFileExtensionKind.Reqif);
+
+            var attributes = ExtractRootAttributes(output);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(attributes["xmlns:xsi"], Is.EqualTo(XsiNamespace), "the xsi namespace declaration was not retained");
+                Assert.That(attributes["xsi:schemaLocation"], Is.EqualTo(schemaLocation), "the xsi:schemaLocation attribute was not retained");
+            });
+        }
+
+        [Test]
+        public void Verify_that_repeated_serialization_does_not_duplicate_namespace_declarations()
+        {
+            var deserializer = new ReqIFDeserializer();
+            var serializer = new ReqIFSerializer();
+
+            var reqif = deserializer.Deserialize(this.datatypeDemoPath).First();
+
+            // serialize twice from the same object; the second pass must not accumulate extra declarations
+            using (var first = new MemoryStream())
+            {
+                serializer.Serialize(new[] { reqif }, first, SupportedFileExtensionKind.Reqif);
+            }
+
+            using var second = new MemoryStream();
+            serializer.Serialize(new[] { reqif }, second, SupportedFileExtensionKind.Reqif);
+
+            var attributes = ExtractRootAttributes(second);
+
+            Assert.That(attributes["xmlns:xhtml"], Is.EqualTo("http://www.w3.org/1999/xhtml"));
+        }
+
+        /// <summary>
+        /// Reads the attributes declared on the <c>REQ-IF</c> root element of a serialized document, keyed by
+        /// their qualified name (e.g. <c>xmlns</c>, <c>xmlns:configuration</c>, <c>xsi:schemaLocation</c>).
+        /// </summary>
+        private static IDictionary<string, string> ExtractRootAttributes(Stream stream)
+        {
+            stream.Position = 0;
+
+            var attributes = new Dictionary<string, string>();
+
+            using var reader = XmlReader.Create(stream);
+
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.Element && reader.Name == "REQ-IF")
+                {
+                    if (reader.MoveToFirstAttribute())
+                    {
+                        do
+                        {
+                            attributes[reader.Name] = reader.Value;
+                        }
+                        while (reader.MoveToNextAttribute());
+                    }
+
+                    break;
+                }
+            }
+
+            return attributes;
+        }
+    }
+}

--- a/ReqIFSharp.Tests/NamespaceRetentionTestFixture.cs
+++ b/ReqIFSharp.Tests/NamespaceRetentionTestFixture.cs
@@ -253,7 +253,7 @@ namespace ReqIFSharp.Tests
         /// <summary>
         /// Reads the <c>REQ-IF</c> root attributes of every <c>.reqif</c> entry contained in a <c>.reqifz</c> archive.
         /// </summary>
-        private static IList<IDictionary<string, string>> ExtractArchiveRootAttributes(Stream reqifzStream)
+        private static List<IDictionary<string, string>> ExtractArchiveRootAttributes(Stream reqifzStream)
         {
             if (reqifzStream.CanSeek)
             {

--- a/ReqIFSharp/DefaultXmlAttributeFactory.cs
+++ b/ReqIFSharp/DefaultXmlAttributeFactory.cs
@@ -38,6 +38,11 @@ namespace ReqIFSharp
         public const string XHTMLNameSpaceUri = @"http://www.w3.org/1999/xhtml";
 
         /// <summary>
+        /// The reserved URI used by the XML parser for namespace declaration attributes (xmlns / xmlns:prefix)
+        /// </summary>
+        public const string XmlNamespaceDeclarationUri = @"http://www.w3.org/2000/xmlns/";
+
+        /// <summary>
         /// Creates the XHTML namespace attribute in case the <see cref="ReqIF"/> document
         /// contains XHTML data
         /// </summary>
@@ -56,6 +61,7 @@ namespace ReqIFSharp
                 {
                     LocalName = "xhtml",
                     Prefix = "xmlns",
+                    NamespaceUri = XmlNamespaceDeclarationUri,
                     Value = XHTMLNameSpaceUri
                 };
 

--- a/ReqIFSharp/ReqIF.cs
+++ b/ReqIFSharp/ReqIF.cs
@@ -116,6 +116,7 @@ namespace ReqIFSharp
                     {
                         Prefix = reader.Prefix,
                         LocalName = reader.LocalName,
+                        NamespaceUri = reader.NamespaceURI,
                         Value = reader.Value
                     };
 
@@ -187,6 +188,7 @@ namespace ReqIFSharp
                     {
                         Prefix = reader.Prefix,
                         LocalName = reader.LocalName,
+                        NamespaceUri = reader.NamespaceURI,
                         Value = reader.Value
                     };
 
@@ -290,30 +292,22 @@ namespace ReqIFSharp
         /// </param>
         private void WriteNameSpaceAttributes(XmlWriter writer)
         {
-            if (attributes.TrueForAll(x => x.Value != DefaultXmlAttributeFactory.XHTMLNameSpaceUri))
+            foreach (var xmlAttribute in this.QueryNameSpaceAttributes())
             {
-                var xmlAttribute = DefaultXmlAttributeFactory.CreateXHTMLNameSpaceAttribute(this);
-                if (xmlAttribute != null)
+                if (xmlAttribute.Prefix == "xmlns")
                 {
-                    this.attributes.Add(xmlAttribute);
+                    // prefixed namespace declaration: xmlns:prefix="uri"
+                    writer.WriteAttributeString(xmlAttribute.Prefix, xmlAttribute.LocalName, null, xmlAttribute.Value);
                 }
-            }
-
-            foreach (var xmlAttribute in this.attributes)
-            {
-                if (xmlAttribute.Prefix != string.Empty)
+                else if (xmlAttribute.Prefix != string.Empty)
                 {
-                    if (xmlAttribute.Prefix == "xmlns")
-                    {
-                        writer.WriteAttributeString(xmlAttribute.Prefix, xmlAttribute.LocalName, null, xmlAttribute.Value);
-                    }
-                    else
-                    {
-                        writer.WriteAttributeString(xmlAttribute.LocalName, xmlAttribute.Prefix, xmlAttribute.Value);
-                    }
+                    // ordinary prefixed attribute (e.g. xsi:schemaLocation): the namespace URI the
+                    // prefix is bound to is required to emit it faithfully
+                    writer.WriteAttributeString(xmlAttribute.Prefix, xmlAttribute.LocalName, xmlAttribute.NamespaceUri, xmlAttribute.Value);
                 }
                 else
                 {
+                    // default namespace declaration (xmlns="...") or an unprefixed attribute
                     writer.WriteAttributeString(xmlAttribute.LocalName, xmlAttribute.Value);
                 }
             }
@@ -327,33 +321,50 @@ namespace ReqIFSharp
         /// </param>
         private async Task WriteNameSpaceAttributesAsync(XmlWriter writer)
         {
-            if (attributes.TrueForAll(x => x.Value != DefaultXmlAttributeFactory.XHTMLNameSpaceUri))
+            foreach (var xmlAttribute in this.QueryNameSpaceAttributes())
+            {
+                if (xmlAttribute.Prefix == "xmlns")
+                {
+                    // prefixed namespace declaration: xmlns:prefix="uri"
+                    await writer.WriteAttributeStringAsync(xmlAttribute.Prefix, xmlAttribute.LocalName, null, xmlAttribute.Value);
+                }
+                else if (xmlAttribute.Prefix != string.Empty)
+                {
+                    // ordinary prefixed attribute (e.g. xsi:schemaLocation): the namespace URI the
+                    // prefix is bound to is required to emit it faithfully
+                    await writer.WriteAttributeStringAsync(xmlAttribute.Prefix, xmlAttribute.LocalName, xmlAttribute.NamespaceUri, xmlAttribute.Value);
+                }
+                else
+                {
+                    // default namespace declaration (xmlns="...") or an unprefixed attribute
+                    await writer.WriteAttributeStringAsync(null, xmlAttribute.LocalName, null, xmlAttribute.Value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the namespace attributes that are to be written to the REQ-IF XML element: the attributes
+        /// captured when the document was read, plus the XHTML namespace declaration when the document
+        /// contains XHTML data and does not already declare it.
+        /// </summary>
+        /// <returns>
+        /// the <see cref="IEnumerable{XmlAttribute}"/> to serialize; the captured <see cref="attributes"/>
+        /// are not mutated so the <see cref="ReqIF"/> can be serialized more than once.
+        /// </returns>
+        private IEnumerable<XmlAttribute> QueryNameSpaceAttributes()
+        {
+            var namespaceAttributes = new List<XmlAttribute>(this.attributes);
+
+            if (namespaceAttributes.TrueForAll(x => x.Value != DefaultXmlAttributeFactory.XHTMLNameSpaceUri))
             {
                 var xmlAttribute = DefaultXmlAttributeFactory.CreateXHTMLNameSpaceAttribute(this);
                 if (xmlAttribute != null)
                 {
-                    this.attributes.Add(xmlAttribute);
+                    namespaceAttributes.Add(xmlAttribute);
                 }
             }
 
-            foreach (var xmlAttribute in this.attributes)
-            {
-                if (xmlAttribute.Prefix != string.Empty)
-                {
-                    if (xmlAttribute.Prefix == "xmlns")
-                    {
-                        await writer.WriteAttributeStringAsync(xmlAttribute.Prefix, xmlAttribute.LocalName, null, xmlAttribute.Value);
-                    }
-                    else
-                    {
-                        await writer.WriteAttributeStringAsync(null, xmlAttribute.LocalName, xmlAttribute.Prefix, xmlAttribute.Value);
-                    }
-                }
-                else
-                {
-                    await writer.WriteAttributeStringAsync(null, xmlAttribute.LocalName, null, xmlAttribute.Value);
-                }
-            }
+            return namespaceAttributes;
         }
 
         /// <summary>

--- a/ReqIFSharp/ReqIFSerializer.cs
+++ b/ReqIFSharp/ReqIFSerializer.cs
@@ -50,7 +50,7 @@ namespace ReqIFSharp
 
             var fileExtensionKind = fileUri.ConvertPathToSupportedFileExtensionKind();
 
-            using (var fileStream = new FileStream(fileUri, FileMode.OpenOrCreate))
+            using (var fileStream = new FileStream(fileUri, FileMode.Create))
             {
                 this.Serialize(reqifs, fileStream, fileExtensionKind);
             }
@@ -121,7 +121,7 @@ namespace ReqIFSharp
 
             var fileExtensionKind = fileUri.ConvertPathToSupportedFileExtensionKind();
 
-            using (var fileStream = new FileStream(fileUri, FileMode.OpenOrCreate))
+            using (var fileStream = new FileStream(fileUri, FileMode.Create))
             {
                 await this.SerializeAsync(reqifs, fileStream, fileExtensionKind, token);
             }

--- a/ReqIFSharp/XmlAttribute.cs
+++ b/ReqIFSharp/XmlAttribute.cs
@@ -36,6 +36,17 @@ namespace ReqIFSharp
         internal string LocalName { get; set; }
 
         /// <summary>
+        /// Gets or sets the namespace URI of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// For namespace declarations (<c>xmlns</c> / <c>xmlns:prefix</c>) this is the reserved
+        /// <c>http://www.w3.org/2000/xmlns/</c> URI; for ordinary prefixed attributes (e.g.
+        /// <c>xsi:schemaLocation</c>) it is the URI the prefix is bound to. Captured on read so the
+        /// attribute can be re-emitted faithfully.
+        /// </remarks>
+        internal string NamespaceUri { get; set; }
+
+        /// <summary>
         /// Gets or sets the value of the attribute.
         /// </summary>
         internal string Value { get; set; }


### PR DESCRIPTION
## Summary

Fixes #44 — when a `.reqif` with custom namespaces is deserialized and serialized to a new destination, the declared namespaces (and other root attributes) should be retained.

The capture/re-emit mechanism on the `REQ-IF` root already round-tripped the default and `xmlns:*` declarations, but it had real defects for prefixed, non-`xmlns` attributes (e.g. `xsi:schemaLocation`) and lacked any test coverage. While adding that coverage, a latent file-output truncation bug was also surfaced and fixed.

## Changes

- **Capture the namespace URI on read** — `XmlAttribute` gains a `NamespaceUri`; `ReqIF.ReadXml` / `ReadXmlAsync` store `reader.NamespaceURI` for each captured root attribute.
- **Correct write of prefixed attributes** — `WriteNameSpaceAttributes` / `WriteNameSpaceAttributesAsync` now emit ordinary prefixed attributes (e.g. `xsi:schemaLocation`) using the captured namespace URI instead of passing the *prefix* where a namespace URI is expected. The sync and async paths are aligned (they previously diverged).
- **No mutation of captured state** — the synthesized XHTML namespace declaration is built into a local list rather than appended to the captured `attributes`, so the same `ReqIF` can be serialized repeatedly without accumulating duplicate declarations.
- **`FileMode.Create` for file output** — `ReqIFSerializer.Serialize`/`SerializeAsync` (file overloads) used `FileMode.OpenOrCreate`, which does not truncate; serializing a shorter document over a longer existing file left trailing bytes and produced invalid XML. Switched to `FileMode.Create`.

## Tests

New `NamespaceRetentionTestFixture` (round-trips through deserialize → serialize → re-parse the root):
- `xmlns` default + `xmlns:configuration` / `xmlns:id` / `xmlns:xhtml` retained (sync **and** async).
- `xmlns:xsi` + `xsi:schemaLocation` prefixed attribute retained (fails before the fix).
- repeated serialization does not duplicate declarations.

## Verification

- `dotnet build ReqIFSharp.sln -c Release` — 0 warnings / 0 errors.
- `dotnet test ReqIFSharp.sln` — **380 tests pass** (296 core incl. 4 new, 84 extensions). The two `DefaultValueDemo` round-trip-to-file tests, which exercised the `OpenOrCreate` path, now pass.

No `.csproj` / version changes.